### PR TITLE
Fix link to adamdrake.com

### DIFF
--- a/chapter-10-refs.md
+++ b/chapter-10-refs.md
@@ -29,7 +29,7 @@ Chapter 10 References
     Machines Corporation, July 1962.
 
 1.  Adam Drake:
-    “[Command-Line Tools Can Be 235x Faster than Your Hadoop Cluster](http://aadrake.com/command-line-tools-can-be-235x-faster-than-your-hadoop-cluster.html),” *aadrake.com*, January 25, 2014.
+    “[Command-Line Tools Can Be 235x Faster than Your Hadoop Cluster](https://adamdrake.com/command-line-tools-can-be-235x-faster-than-your-hadoop-cluster.html),” *adamdrake.com*, January 18, 2014.
 
 1.  “[GNU Coreutils 8.23 Documentation](http://www.gnu.org/software/coreutils/manual/html_node/index.html),” Free Software Foundation, Inc., 2014.
 


### PR DESCRIPTION
The domain seems to have moved from aadrake.com to adamdrake.com. Also,
update the post date from Jan 25 to Jan 18.