### PR TITLE
Update Martin Kleppmann link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Literature References
 ---------------------
 
 This repository accompanies the book [Designing Data-Intensive Applications](http://dataintensive.net/)
-by [Martin Kleppmann](https://www.google.co.uk/maps), published by
+by [Martin Kleppmann](http://martin.kleppmann.com/), published by
 [O'Reilly Media](http://shop.oreilly.com/product/0636920032175.do).
 
 The book contains a large number of references to further reading material for anyone who wants to


### PR DESCRIPTION
Hi there!

I noticed an oddity related to a hyperlink for Martin Kleppmann. The link, strangely, pointed to Google Maps instead of what I assume should be Martin Kleppmann's website or relevant content.

The misdirected link initially led me to consider whether it was intended to reference the 'Drawing a *map* of distributed data systems' article, especially since it is linked later in the documentation. Alternatively, the link might have been intended to showcase this delightful picture of [Martin holding the *map*](https://www.oreilly.com/content/wp-content/uploads/sites/2/2019/06/Martin_holding_map-221ef9bdb026756ecee52ad87867d084.jpg)? 😄

Also, as a good practice, I suggest updating all links in the README to HTTPS (for the sites that support it). I've kept the link HTTP to be consistent with the other link to the website on the page, but the site does support HTTPS. 

Please let me know what you think. I'm happy to update links!