### PR TITLE
fix chapter 5 ref 1 broken link

### DIFF
--- a/chapter-05-refs.md
+++ b/chapter-05-refs.md
@@ -5,7 +5,7 @@ Chapter 5 References
 --------------------
 
 1.  Bruce G. Lindsay, Patricia Griffiths Selinger, C. Galtieri, et al.:
-    “[Notes on Distributed Databases](http://domino.research.ibm.com/library/cyberdig.nsf/papers/A776EC17FC2FCE73852579F100578964/$File/RJ2571.pdf),” IBM Research, Research Report RJ2571(33471), July 1979.
+    “[Notes on Distributed Databases](https://dominoweb.draco.res.ibm.com/reports/RJ2571.pdf),” IBM Research, Research Report RJ2571(33471), July 1979.
 
 1.  “[Oracle Active Data Guard Real-Time Data Protection and Availability](http://www.oracle.com/technetwork/database/availability/active-data-guard-wp-12c-1896127.pdf),” Oracle White Paper, June 2013.
 


### PR DESCRIPTION
The old link seems to be broken, searching "notes on distributed databases" gives me [RJ2571 (33471)7/14/79](https://dominoweb.draco.res.ibm.com/reports/RJ2571.pdf), and looks like this is the right link, so let's update the old link.