### PR TITLE
style: edit whitespace

### DIFF
--- a/chapter-01-refs.md
+++ b/chapter-01-refs.md
@@ -36,10 +36,10 @@ Chapter 1 References
     [doi:10.1145/2670979.2670986](http://dx.doi.org/10.1145/2670979.2670986)
 
 1.  Nelson Minar:
-      “[Leap Second Crashes Half the Internet](http://www.somebits.com/weblog/tech/bad/leap-second-2012.html),” *somebits.com*, July 3, 2012.
+    “[Leap Second Crashes Half the Internet](http://www.somebits.com/weblog/tech/bad/leap-second-2012.html),” *somebits.com*, July 3, 2012.
 
 1.  Amazon Web Services:
-      “[Summary of the Amazon EC2 and Amazon RDS Service Disruption in the US East Region](http://aws.amazon.com/message/65648/),” *aws.amazon.com*, April 29, 2011.
+    “[Summary of the Amazon EC2 and Amazon RDS Service Disruption in the US East Region](http://aws.amazon.com/message/65648/),” *aws.amazon.com*, April 29, 2011.
 
 1.  Richard I. Cook:
     “[How Complex Systems Fail](https://www.adaptivecapacitylabs.com/HowComplexSystemsFail.pdf),” Cognitive Technologies Laboratory, April 2000.
@@ -52,7 +52,7 @@ Chapter 1 References
     Internet Technologies and Systems* (USITS), March 2003.
 
 1.  Nathan Marz:
-      “[Principles of Software Engineering, Part 1](http://nathanmarz.com/blog/principles-of-software-engineering-part-1.html),” *nathanmarz.com*, April 2, 2013.
+    “[Principles of Software Engineering, Part 1](http://nathanmarz.com/blog/principles-of-software-engineering-part-1.html),” *nathanmarz.com*, April 2, 2013.
 
 1.  Michael Jurewitz:
     “[The Human Impact of Bugs](http://jury.me/blog/2013/3/14/the-human-impact-of-bugs),”

--- a/chapter-01-refs.md
+++ b/chapter-01-refs.md
@@ -113,7 +113,7 @@ Chapter 1 References
     *4th Conference on Pattern Languages of Programs* (PLoP),
     September 1997.
 
-1.  Frederick P Brooks: “No Silver Bullet – Essence and
+1.  Frederick P. Brooks: “No Silver Bullet – Essence and
     Accident in Software Engineering,” in *The Mythical Man-Month*, Anniversary
     edition, Addison-Wesley, 1995. ISBN: 978-0-201-83595-3
 

--- a/chapter-01-refs.md
+++ b/chapter-01-refs.md
@@ -130,4 +130,3 @@ Chapter 1 References
     at *32nd Annual IEEE International Computer Software and Applications Conference*
     (COMPSAC), July 2008.
     [doi:10.1109/COMPSAC.2008.50](http://dx.doi.org/10.1109/COMPSAC.2008.50)
-

--- a/chapter-01-refs.md
+++ b/chapter-01-refs.md
@@ -36,10 +36,10 @@ Chapter 1 References
     [doi:10.1145/2670979.2670986](http://dx.doi.org/10.1145/2670979.2670986)
 
 1.  Nelson Minar:
-      “[Leap Second Crashes Half   the Internet](http://www.somebits.com/weblog/tech/bad/leap-second-2012.html),” *somebits.com*, July 3, 2012.
+      “[Leap Second Crashes Half the Internet](http://www.somebits.com/weblog/tech/bad/leap-second-2012.html),” *somebits.com*, July 3, 2012.
 
 1.  Amazon Web Services:
-      “[Summary of the Amazon EC2 and Amazon RDS Service   Disruption in the US East Region](http://aws.amazon.com/message/65648/),” *aws.amazon.com*, April 29, 2011.
+      “[Summary of the Amazon EC2 and Amazon RDS Service Disruption in the US East Region](http://aws.amazon.com/message/65648/),” *aws.amazon.com*, April 29, 2011.
 
 1.  Richard I. Cook:
     “[How Complex Systems Fail](https://www.adaptivecapacitylabs.com/HowComplexSystemsFail.pdf),” Cognitive Technologies Laboratory, April 2000.
@@ -52,7 +52,7 @@ Chapter 1 References
     Internet Technologies and Systems* (USITS), March 2003.
 
 1.  Nathan Marz:
-      “[Principles   of Software Engineering, Part 1](http://nathanmarz.com/blog/principles-of-software-engineering-part-1.html),” *nathanmarz.com*, April 2, 2013.
+      “[Principles of Software Engineering, Part 1](http://nathanmarz.com/blog/principles-of-software-engineering-part-1.html),” *nathanmarz.com*, April 2, 2013.
 
 1.  Michael Jurewitz:
     “[The Human Impact of Bugs](http://jury.me/blog/2013/3/14/the-human-impact-of-bugs),”

--- a/chapter-02-refs.md
+++ b/chapter-02-refs.md
@@ -180,4 +180,3 @@ Chapter 2 References
 1.  Fons Rademakers:
       “[ROOT for Big Data Analysis](https://indico.cern.ch/event/246453/contributions/1566610/attachments/423154/587535/ROOT-BigData-Analysis-London-2013.pdf),” at *Workshop on the Future of Big Data Management*,
       London, UK, June 2013.
-

--- a/chapter-02-refs.md
+++ b/chapter-02-refs.md
@@ -22,11 +22,11 @@ Chapter 2 References
     “[NoSQL: What's in a Name?](https://web.archive.org/web/20190623045155/http://blog.sym-link.com/2009/10/30/nosql_whats_in_a_name.html),” *blog.sym-link.com*, October 30, 2009.
 
 1.  James Phillips:
-      “[Surprises in Our NoSQL Adoption Survey](http://blog.couchbase.com/nosql-adoption-survey-surprises),” *blog.couchbase.com*, February 8, 2012.
+    “[Surprises in Our NoSQL Adoption Survey](http://blog.couchbase.com/nosql-adoption-survey-surprises),” *blog.couchbase.com*, February 8, 2012.
 
 1.  Michael Wagner:
-      *SQL/XML:2006 – Evaluierung der Standardkonformität ausgewählter Datenbanksysteme*.
-      Diplomica Verlag, Hamburg, 2010. ISBN: 978-3-836-64609-3
+    *SQL/XML:2006 – Evaluierung der Standardkonformität ausgewählter Datenbanksysteme*.
+    Diplomica Verlag, Hamburg, 2010. ISBN: 978-3-836-64609-3
 
 1.  “[XML Data (SQL Server)](https://docs.microsoft.com/en-us/sql/relational-databases/xml/xml-data-sql-server?view=sql-server-ver15),” SQL Server documentation, *docs.microsoft.com*, 2013.
 
@@ -172,11 +172,11 @@ Chapter 2 References
     “[Cascalog](https://github.com/nathanmarz/cascalog)," *github.com*.
 
 1.  Dennis A. Benson,
-      Ilene Karsch-Mizrachi, David J. Lipman, et al.:
-      “[GenBank](https://academic.oup.com/nar/article/36/suppl_1/D25/2507746),”
-      *Nucleic Acids Research*, volume 36, Database issue, pages D25–D30, December 2007.
-      [doi:10.1093/nar/gkm929](http://dx.doi.org/10.1093/nar/gkm929)
+    Ilene Karsch-Mizrachi, David J. Lipman, et al.:
+    “[GenBank](https://academic.oup.com/nar/article/36/suppl_1/D25/2507746),”
+    *Nucleic Acids Research*, volume 36, Database issue, pages D25–D30, December 2007.
+    [doi:10.1093/nar/gkm929](http://dx.doi.org/10.1093/nar/gkm929)
 
 1.  Fons Rademakers:
-      “[ROOT for Big Data Analysis](https://indico.cern.ch/event/246453/contributions/1566610/attachments/423154/587535/ROOT-BigData-Analysis-London-2013.pdf),” at *Workshop on the Future of Big Data Management*,
-      London, UK, June 2013.
+    “[ROOT for Big Data Analysis](https://indico.cern.ch/event/246453/contributions/1566610/attachments/423154/587535/ROOT-BigData-Analysis-London-2013.pdf),” at *Workshop on the Future of Big Data Management*,
+    London, UK, June 2013.

--- a/chapter-02-refs.md
+++ b/chapter-02-refs.md
@@ -22,7 +22,7 @@ Chapter 2 References
     “[NoSQL: What's in a Name?](https://web.archive.org/web/20190623045155/http://blog.sym-link.com/2009/10/30/nosql_whats_in_a_name.html),” *blog.sym-link.com*, October 30, 2009.
 
 1.  James Phillips:
-      “[Surprises in Our NoSQL   Adoption Survey](http://blog.couchbase.com/nosql-adoption-survey-surprises),” *blog.couchbase.com*, February 8, 2012.
+      “[Surprises in Our NoSQL Adoption Survey](http://blog.couchbase.com/nosql-adoption-survey-surprises),” *blog.couchbase.com*, February 8, 2012.
 
 1.  Michael Wagner:
       *SQL/XML:2006 – Evaluierung der Standardkonformität ausgewählter Datenbanksysteme*.
@@ -30,7 +30,7 @@ Chapter 2 References
 
 1.  “[XML Data (SQL Server)](https://docs.microsoft.com/en-us/sql/relational-databases/xml/xml-data-sql-server?view=sql-server-ver15),” SQL Server documentation, *docs.microsoft.com*, 2013.
 
-1.  “[PostgreSQL   9.3.1 Documentation](http://www.postgresql.org/docs/9.3/static/index.html),” The PostgreSQL Global Development Group, 2013.
+1.  “[PostgreSQL 9.3.1 Documentation](http://www.postgresql.org/docs/9.3/static/index.html),” The PostgreSQL Global Development Group, 2013.
 
 1.  “[The MongoDB 2.4 Manual](http://docs.mongodb.org/manual/),” MongoDB, Inc., 2013.
 

--- a/chapter-02-refs.md
+++ b/chapter-02-refs.md
@@ -114,8 +114,7 @@ Chapter 2 References
 
 1.  Joseph M. Hellerstein:
     “[The Declarative Imperative: Experiences and Conjectures in Distributed Logic](http://www.eecs.berkeley.edu/Pubs/TechRpts/2010/EECS-2010-90.pdf),” Electrical Engineering and
-    Computer Sciences, University of California at Berkeley, Tech report UCB/EECS-2010-90, June
-    2010.
+    Computer Sciences, University of California at Berkeley, Tech report UCB/EECS-2010-90, June 2010.
 
 1.  Jeffrey Dean and Sanjay Ghemawat:
     “[MapReduce: Simplified Data Processing on Large Clusters](https://research.google/pubs/pub62/),” at *6th USENIX Symposium on Operating System Design and

--- a/chapter-03-refs.md
+++ b/chapter-03-refs.md
@@ -254,4 +254,3 @@ Chapter 3 References
     “[Data Cube: A Relational Aggregation Operator Generalizing Group-By, Cross-Tab, and Sub-Totals](http://arxiv.org/pdf/cs/0701155.pdf),” *Data Mining and Knowledge
     Discovery*, volume 1, number 1, pages 29–53, March 2007.
     [doi:10.1023/A:1009726021843](http://dx.doi.org/10.1023/A:1009726021843)
-

--- a/chapter-03-refs.md
+++ b/chapter-03-refs.md
@@ -15,14 +15,14 @@ Chapter 3 References
     “[Bitcask: A Log-Structured Hash Table for Fast Key/Value Data](https://riak.com/assets/bitcask-intro.pdf),” Basho Technologies, April 2010.
 
 1.  Yinan Li, Bingsheng He, Robin Jun Yang, et al.:
-      “[Tree Indexing on Solid State Drives](http://pages.cs.wisc.edu/~yinan/paper/fdtree_pvldb.pdf),”
-      *Proceedings of the VLDB Endowment*, volume 3, number 1, pages 1195–1206,
-      September 2010.
+    “[Tree Indexing on Solid State Drives](http://pages.cs.wisc.edu/~yinan/paper/fdtree_pvldb.pdf),”
+    *Proceedings of the VLDB Endowment*, volume 3, number 1, pages 1195–1206,
+    September 2010.
 
 1.  Goetz Graefe:
-      “[Modern B-Tree Techniques](https://w6113.github.io/files/papers/btreesurvey-graefe.pdf),”
-      *Foundations and Trends in Databases*, volume 3, number 4, pages 203–402, August 2011.
-      [doi:10.1561/1900000028](http://dx.doi.org/10.1561/1900000028)
+    “[Modern B-Tree Techniques](https://w6113.github.io/files/papers/btreesurvey-graefe.pdf),”
+    *Foundations and Trends in Databases*, volume 3, number 4, pages 203–402, August 2011.
+    [doi:10.1561/1900000028](http://dx.doi.org/10.1561/1900000028)
 
 1.  Jeffrey Dean and Sanjay Ghemawat:
     “[LevelDB Implementation Notes](https://github.com/google/leveldb/blob/master/doc/impl.md),”
@@ -83,12 +83,12 @@ Chapter 3 References
     [doi:10.1145/130283.130338](http://dx.doi.org/10.1145/130283.130338)
 
 1.  Howard Chu:
-      “[LDAP at Lightning Speed]( https://buildstuff14.sched.com/event/08a1a368e272eb599a52e08b4c3c779d),”
-      at *Build Stuff '14*, November 2014.
+    “[LDAP at Lightning Speed]( https://buildstuff14.sched.com/event/08a1a368e272eb599a52e08b4c3c779d),”
+    at *Build Stuff '14*, November 2014.
 
 1.  Bradley C. Kuszmaul:
-      “[A Comparison of Fractal Trees to Log-Structured Merge (LSM) Trees](http://www.pandademo.com/wp-content/uploads/2017/12/A-Comparison-of-Fractal-Trees-to-Log-Structured-Merge-LSM-Trees.pdf),” *tokutek.com*,
-      April 22, 2014.
+    “[A Comparison of Fractal Trees to Log-Structured Merge (LSM) Trees](http://www.pandademo.com/wp-content/uploads/2017/12/A-Comparison-of-Fractal-Trees-to-Log-Structured-Merge-LSM-Trees.pdf),” *tokutek.com*,
+    April 22, 2014.
 
 1.  Manos Athanassoulis, Michael S. Kester,
     Lukas M. Maas, et al.: “[Designing Access Methods: The RUM Conjecture](http://openproceedings.org/2016/conf/edbt/paper-12.pdf),” at *19th International Conference on Extending Database

--- a/chapter-03-refs.md
+++ b/chapter-03-refs.md
@@ -39,8 +39,7 @@ Chapter 3 References
     “[Bigtable: A Distributed Storage System for Structured Data](https://research.google/pubs/pub27898/),” at *7th USENIX Symposium on Operating System Design and
     Implementation* (OSDI), November 2006.
 
-1.  Patrick
-    O'Neil, Edward Cheng, Dieter Gawlick, and Elizabeth O'Neil:
+1.  Patrick O'Neil, Edward Cheng, Dieter Gawlick, and Elizabeth O'Neil:
     “[The Log-Structured Merge-Tree (LSM-Tree)](http://www.cs.umb.edu/~poneil/lsmtree.pdf),”
     *Acta Informatica*, volume 33, number 4, pages 351–385, June 1996.
     [doi:10.1007/s002360050048](http://dx.doi.org/10.1007/s002360050048)
@@ -90,8 +89,8 @@ Chapter 3 References
     “[A Comparison of Fractal Trees to Log-Structured Merge (LSM) Trees](http://www.pandademo.com/wp-content/uploads/2017/12/A-Comparison-of-Fractal-Trees-to-Log-Structured-Merge-LSM-Trees.pdf),” *tokutek.com*,
     April 22, 2014.
 
-1.  Manos Athanassoulis, Michael S. Kester,
-    Lukas M. Maas, et al.: “[Designing Access Methods: The RUM Conjecture](http://openproceedings.org/2016/conf/edbt/paper-12.pdf),” at *19th International Conference on Extending Database
+1.  Manos Athanassoulis, Michael S. Kester, Lukas M. Maas, et al.:
+    “[Designing Access Methods: The RUM Conjecture](http://openproceedings.org/2016/conf/edbt/paper-12.pdf),” at *19th International Conference on Extending Database
     Technology* (EDBT), March 2016.
     [doi:10.5441/002/edbt.2016.42](http://dx.doi.org/10.5441/002/edbt.2016.42)
 

--- a/chapter-03-refs.md
+++ b/chapter-03-refs.md
@@ -87,7 +87,7 @@ Chapter 3 References
       at *Build Stuff '14*, November 2014.
 
 1.  Bradley C. Kuszmaul:
-      “[A   Comparison of Fractal Trees to Log-Structured Merge (LSM) Trees](http://www.pandademo.com/wp-content/uploads/2017/12/A-Comparison-of-Fractal-Trees-to-Log-Structured-Merge-LSM-Trees.pdf),” *tokutek.com*,
+      “[A Comparison of Fractal Trees to Log-Structured Merge (LSM) Trees](http://www.pandademo.com/wp-content/uploads/2017/12/A-Comparison-of-Fractal-Trees-to-Log-Structured-Merge-LSM-Trees.pdf),” *tokutek.com*,
       April 22, 2014.
 
 1.  Manos Athanassoulis, Michael S. Kester,

--- a/chapter-04-refs.md
+++ b/chapter-04-refs.md
@@ -17,10 +17,10 @@ Chapter 4 References
       July 30, 2014.
 
 1.  Steve Breen:
-      “[What   Do WebLogic, WebSphere, JBoss, Jenkins, OpenNMS, and Your Application Have in Common? This   Vulnerability](http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/),” *foxglovesecurity.com*, November 6, 2015.
+      “[What Do WebLogic, WebSphere, JBoss, Jenkins, OpenNMS, and Your Application Have in Common? This Vulnerability](http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/),” *foxglovesecurity.com*, November 6, 2015.
 
 1.  Patrick McKenzie:
-      “[What   the Rails Security Issue Means for Your Startup](http://www.kalzumeus.com/2013/01/31/what-the-rails-security-issue-means-for-your-startup/),” *kalzumeus.com*, January 31, 2013.
+      “[What the Rails Security Issue Means for Your Startup](http://www.kalzumeus.com/2013/01/31/what-the-rails-security-issue-means-for-your-startup/),” *kalzumeus.com*, January 31, 2013.
 
 1.  Eishay Smith:
       “[jvm-serializers wiki](https://github.com/eishay/jvm-serializers/wiki),”
@@ -69,7 +69,7 @@ Chapter 4 References
     March 2009.
 
 1.  Aditya Auradkar and Tom Quiggle:
-      “[Introducing   Espresso—LinkedIn's Hot New Distributed Document Store](https://engineering.linkedin.com/espresso/introducing-espresso-linkedins-hot-new-distributed-document-store),” *engineering.linkedin.com*, January 21, 2015.
+      “[Introducing Espresso—LinkedIn's Hot New Distributed Document Store](https://engineering.linkedin.com/espresso/introducing-espresso-linkedins-hot-new-distributed-document-store),” *engineering.linkedin.com*, January 21, 2015.
 
 1.  Jay Kreps:
     “[Putting Apache Kafka to Use: A Practical Guide to Building a Stream Data Platform (Part 2)](http://blog.confluent.io/2015/02/25/stream-data-platform-2/),” *blog.confluent.io*,
@@ -150,7 +150,7 @@ Chapter 4 References
 1.  “[gRPC concepts](https://grpc.io/docs/guides/concepts/),” The Linux Foundation, *grpc.io*.
 
 1.  Aditya Narayan and Irina Singh:
-      “[Designing   and Versioning Compatible Web Services](https://web.archive.org/web/20141016000136/http://www.ibm.com/developerworks/websphere/library/techarticles/0705_narayan/0705_narayan.html),” *ibm.com*, March 28, 2007.
+      “[Designing and Versioning Compatible Web Services](https://web.archive.org/web/20141016000136/http://www.ibm.com/developerworks/websphere/library/techarticles/0705_narayan/0705_narayan.html),” *ibm.com*, March 28, 2007.
 
 1.  Troy Hunt:
     “[Your API Versioning Is Wrong, Which Is Why I Decided to Do It 3 Different Wrong Ways](http://www.troyhunt.com/2014/02/your-api-versioning-is-wrong-which-is.html),” *troyhunt.com*,
@@ -159,13 +159,13 @@ Chapter 4 References
 1.  “[API Upgrades](https://stripe.com/docs/upgrades),” Stripe, Inc., April 2015.
 
 1.  Jonas Bonér:
-      “[Upgrade in an   Akka Cluster](http://grokbase.com/t/gg/akka-user/138wd8j9e3/upgrade-in-an-akka-cluster),” email to *akka-user* mailing list, *grokbase.com*, August 28, 2013.
+      “[Upgrade in an Akka Cluster](http://grokbase.com/t/gg/akka-user/138wd8j9e3/upgrade-in-an-akka-cluster),” email to *akka-user* mailing list, *grokbase.com*, August 28, 2013.
 
 1.  Philip A. Bernstein, Sergey Bykov, Alan Geller, et al.:
       “[Orleans: Distributed Virtual Actors for Programmability and Scalability](https://www.microsoft.com/en-us/research/publication/orleans-distributed-virtual-actors-for-programmability-and-scalability/),” Microsoft Research
       Technical Report MSR-TR-2014-41, March 2014.
 
-1.  “[Microsoft Project   Orleans Documentation](http://dotnet.github.io/orleans/),” Microsoft Research, *dotnet.github.io*, 2015.
+1.  “[Microsoft Project Orleans Documentation](http://dotnet.github.io/orleans/),” Microsoft Research, *dotnet.github.io*, 2015.
 
 1.  David Mercer, Sean Hinde, Yinso Chen, and Richard A O'Keefe:
       “[beginner:   Updating Data Structures](http://erlang.org/pipermail/erlang-questions/2007-October/030318.html),” email thread on *erlang-questions* mailing list, *erlang.com*,

--- a/chapter-04-refs.md
+++ b/chapter-04-refs.md
@@ -174,4 +174,3 @@ Chapter 4 References
 1.  Fred Hebert:
       “[Postscript: Maps](http://learnyousomeerlang.com/maps),” *learnyousomeerlang.com*,
       April 9, 2014.
-

--- a/chapter-04-refs.md
+++ b/chapter-04-refs.md
@@ -13,7 +13,7 @@ Chapter 4 References
 1.  “[EsotericSoftware/kryo](https://github.com/EsotericSoftware/kryo),”
     *github.com*, October 2014.
 
-1.  “[CWE-502:   Deserialization of Untrusted Data](http://cwe.mitre.org/data/definitions/502.html),” Common Weakness Enumeration, *cwe.mitre.org*,
+1.  “[CWE-502: Deserialization of Untrusted Data](http://cwe.mitre.org/data/definitions/502.html),” Common Weakness Enumeration, *cwe.mitre.org*,
     July 30, 2014.
 
 1.  Steve Breen:
@@ -168,7 +168,7 @@ Chapter 4 References
 1.  “[Microsoft Project Orleans Documentation](http://dotnet.github.io/orleans/),” Microsoft Research, *dotnet.github.io*, 2015.
 
 1.  David Mercer, Sean Hinde, Yinso Chen, and Richard A O'Keefe:
-    “[beginner:   Updating Data Structures](http://erlang.org/pipermail/erlang-questions/2007-October/030318.html),” email thread on *erlang-questions* mailing list, *erlang.com*,
+    “[beginner: Updating Data Structures](http://erlang.org/pipermail/erlang-questions/2007-October/030318.html),” email thread on *erlang-questions* mailing list, *erlang.com*,
     October 29, 2007.
 
 1.  Fred Hebert:

--- a/chapter-04-refs.md
+++ b/chapter-04-refs.md
@@ -14,17 +14,17 @@ Chapter 4 References
     *github.com*, October 2014.
 
 1.  “[CWE-502:   Deserialization of Untrusted Data](http://cwe.mitre.org/data/definitions/502.html),” Common Weakness Enumeration, *cwe.mitre.org*,
-      July 30, 2014.
+    July 30, 2014.
 
 1.  Steve Breen:
-      “[What Do WebLogic, WebSphere, JBoss, Jenkins, OpenNMS, and Your Application Have in Common? This Vulnerability](http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/),” *foxglovesecurity.com*, November 6, 2015.
+    “[What Do WebLogic, WebSphere, JBoss, Jenkins, OpenNMS, and Your Application Have in Common? This Vulnerability](http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/),” *foxglovesecurity.com*, November 6, 2015.
 
 1.  Patrick McKenzie:
-      “[What the Rails Security Issue Means for Your Startup](http://www.kalzumeus.com/2013/01/31/what-the-rails-security-issue-means-for-your-startup/),” *kalzumeus.com*, January 31, 2013.
+    “[What the Rails Security Issue Means for Your Startup](http://www.kalzumeus.com/2013/01/31/what-the-rails-security-issue-means-for-your-startup/),” *kalzumeus.com*, January 31, 2013.
 
 1.  Eishay Smith:
-      “[jvm-serializers wiki](https://github.com/eishay/jvm-serializers/wiki),”
-      *github.com*, November 2014.
+    “[jvm-serializers wiki](https://github.com/eishay/jvm-serializers/wiki),”
+    *github.com*, November 2014.
 
 1.  “[XML Is a Poor Copy of S-Expressions](http://c2.com/cgi/wiki?XmlIsaPoorCopyOfEssExpressions),” *c2.com* wiki.
 
@@ -69,7 +69,7 @@ Chapter 4 References
     March 2009.
 
 1.  Aditya Auradkar and Tom Quiggle:
-      “[Introducing Espresso—LinkedIn's Hot New Distributed Document Store](https://engineering.linkedin.com/espresso/introducing-espresso-linkedins-hot-new-distributed-document-store),” *engineering.linkedin.com*, January 21, 2015.
+    “[Introducing Espresso—LinkedIn's Hot New Distributed Document Store](https://engineering.linkedin.com/espresso/introducing-espresso-linkedins-hot-new-distributed-document-store),” *engineering.linkedin.com*, January 21, 2015.
 
 1.  Jay Kreps:
     “[Putting Apache Kafka to Use: A Practical Guide to Building a Stream Data Platform (Part 2)](http://blog.confluent.io/2015/02/25/stream-data-platform-2/),” *blog.confluent.io*,
@@ -150,7 +150,7 @@ Chapter 4 References
 1.  “[gRPC concepts](https://grpc.io/docs/guides/concepts/),” The Linux Foundation, *grpc.io*.
 
 1.  Aditya Narayan and Irina Singh:
-      “[Designing and Versioning Compatible Web Services](https://web.archive.org/web/20141016000136/http://www.ibm.com/developerworks/websphere/library/techarticles/0705_narayan/0705_narayan.html),” *ibm.com*, March 28, 2007.
+    “[Designing and Versioning Compatible Web Services](https://web.archive.org/web/20141016000136/http://www.ibm.com/developerworks/websphere/library/techarticles/0705_narayan/0705_narayan.html),” *ibm.com*, March 28, 2007.
 
 1.  Troy Hunt:
     “[Your API Versioning Is Wrong, Which Is Why I Decided to Do It 3 Different Wrong Ways](http://www.troyhunt.com/2014/02/your-api-versioning-is-wrong-which-is.html),” *troyhunt.com*,
@@ -159,18 +159,18 @@ Chapter 4 References
 1.  “[API Upgrades](https://stripe.com/docs/upgrades),” Stripe, Inc., April 2015.
 
 1.  Jonas Bonér:
-      “[Upgrade in an Akka Cluster](http://grokbase.com/t/gg/akka-user/138wd8j9e3/upgrade-in-an-akka-cluster),” email to *akka-user* mailing list, *grokbase.com*, August 28, 2013.
+    “[Upgrade in an Akka Cluster](http://grokbase.com/t/gg/akka-user/138wd8j9e3/upgrade-in-an-akka-cluster),” email to *akka-user* mailing list, *grokbase.com*, August 28, 2013.
 
 1.  Philip A. Bernstein, Sergey Bykov, Alan Geller, et al.:
-      “[Orleans: Distributed Virtual Actors for Programmability and Scalability](https://www.microsoft.com/en-us/research/publication/orleans-distributed-virtual-actors-for-programmability-and-scalability/),” Microsoft Research
-      Technical Report MSR-TR-2014-41, March 2014.
+    “[Orleans: Distributed Virtual Actors for Programmability and Scalability](https://www.microsoft.com/en-us/research/publication/orleans-distributed-virtual-actors-for-programmability-and-scalability/),” Microsoft Research
+    Technical Report MSR-TR-2014-41, March 2014.
 
 1.  “[Microsoft Project Orleans Documentation](http://dotnet.github.io/orleans/),” Microsoft Research, *dotnet.github.io*, 2015.
 
 1.  David Mercer, Sean Hinde, Yinso Chen, and Richard A O'Keefe:
-      “[beginner:   Updating Data Structures](http://erlang.org/pipermail/erlang-questions/2007-October/030318.html),” email thread on *erlang-questions* mailing list, *erlang.com*,
-      October 29, 2007.
+    “[beginner:   Updating Data Structures](http://erlang.org/pipermail/erlang-questions/2007-October/030318.html),” email thread on *erlang-questions* mailing list, *erlang.com*,
+    October 29, 2007.
 
 1.  Fred Hebert:
-      “[Postscript: Maps](http://learnyousomeerlang.com/maps),” *learnyousomeerlang.com*,
-      April 9, 2014.
+    “[Postscript: Maps](http://learnyousomeerlang.com/maps),” *learnyousomeerlang.com*,
+    April 9, 2014.

--- a/chapter-05-refs.md
+++ b/chapter-05-refs.md
@@ -42,11 +42,11 @@ Chapter 5 References
 1.  “[Percona Xtrabackup - Documentation](https://www.percona.com/doc/percona-xtrabackup/2.1/index.html),” Percona LLC, 2014.
 
 1.  Jesse Newland:
-      “[GitHub Availability This Week](https://github.com/blog/1261-github-availability-this-week),” *github.com*, September 14, 2012.
+    “[GitHub Availability This Week](https://github.com/blog/1261-github-availability-this-week),” *github.com*, September 14, 2012.
 
 1.  Mark Imbriaco:
-      “[Downtime Last Saturday](https://github.com/blog/1364-downtime-last-saturday),”
-      *github.com*, December 26, 2012.
+    “[Downtime Last Saturday](https://github.com/blog/1364-downtime-last-saturday),”
+    *github.com*, December 26, 2012.
 
 1.  John Hugg:
     “[‘All in’ with Determinism for Performance and Testing in Distributed Systems](https://www.youtube.com/watch?v=gJRj3vJL4wE),” at *Strange Loop*, September 2015.
@@ -128,22 +128,22 @@ Chapter 5 References
     Systems Principles* (SOSP), October 2007.
 
 1.  Marc Shapiro, Nuno Preguiça, Carlos Baquero,
-      and Marek Zawirski: “[A Comprehensive Study of Convergent and Commutative Replicated Data Types](http://hal.inria.fr/inria-00555588/),” INRIA Research Report no. 7506,
-      January 2011.
+    and Marek Zawirski: “[A Comprehensive Study of Convergent and Commutative Replicated Data Types](http://hal.inria.fr/inria-00555588/),” INRIA Research Report no. 7506,
+    January 2011.
 
 1.  Sam Elliott:
-      “[CRDTs: An UPDATE (or Maybe Just a PUT)](https://speakerdeck.com/lenary/crdts-an-update-or-just-a-put),” at *RICON West*, October 2013.
+    “[CRDTs: An UPDATE (or Maybe Just a PUT)](https://speakerdeck.com/lenary/crdts-an-update-or-just-a-put),” at *RICON West*, October 2013.
 
 1.  Russell Brown:
-      “[A Bluffers Guide to CRDTs in Riak](https://gist.github.com/russelldb/f92f44bdfb619e089a4d),” *gist.github.com*, October 28, 2013.
+    “[A Bluffers Guide to CRDTs in Riak](https://gist.github.com/russelldb/f92f44bdfb619e089a4d),” *gist.github.com*, October 28, 2013.
 
 1.  Benjamin Farinier, Thomas Gazagnaire, and
-      Anil Madhavapeddy: “[Mergeable Persistent Data Structures](http://gazagnaire.org/pub/FGM15.pdf),” at *26es Journées Francophones des Langages Applicatifs* (JFLA),
-      January 2015.
+    Anil Madhavapeddy: “[Mergeable Persistent Data Structures](http://gazagnaire.org/pub/FGM15.pdf),” at *26es Journées Francophones des Langages Applicatifs* (JFLA),
+    January 2015.
 
 1.  Chengzheng Sun and Clarence Ellis:
-      “[Operational Transformation in Real-Time Group Editors: Issues, Algorithms, and Achievements](http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.53.933&rep=rep1&type=pdf),” at
-      *ACM Conference on Computer Supported Cooperative Work* (CSCW), November 1998.
+    “[Operational Transformation in Real-Time Group Editors: Issues, Algorithms, and Achievements](http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.53.933&rep=rep1&type=pdf),” at
+    *ACM Conference on Computer Supported Cooperative Work* (CSCW), November 1998.
 
 1.  Lars Hofhansl:
     “[HBASE-7709: Infinite Loop Possible in Master/Master Replication](https://issues.apache.org/jira/browse/HBASE-7709),” *issues.apache.org*, January 29, 2013.
@@ -158,12 +158,12 @@ Chapter 5 References
     *arXiv:1608.06696*, August 24, 2016.
 
 1.  Joseph Blomstedt:
-      “[Re: Absolute Consistency](https://web.archive.org/web/20190919171316/http://lists.basho.com:80/pipermail/riak-users_lists.basho.com/2012-January/007157.html),” email to *riak-users* mailing list, *lists.basho.com*,
-      January 11, 2012.
+    “[Re: Absolute Consistency](https://web.archive.org/web/20190919171316/http://lists.basho.com:80/pipermail/riak-users_lists.basho.com/2012-January/007157.html),” email to *riak-users* mailing list, *lists.basho.com*,
+    January 11, 2012.
 
 1.  Joseph Blomstedt:
-      “[Bringing Consistency to Riak](https://vimeo.com/51973001),” at *RICON West*,
-      October 2012.
+    “[Bringing Consistency to Riak](https://vimeo.com/51973001),” at *RICON West*,
+    October 2012.
 
 1.  Peter Bailis, Shivaram Venkataraman,
     Michael J. Franklin, et al.:

--- a/chapter-05-refs.md
+++ b/chapter-05-refs.md
@@ -200,8 +200,7 @@ Chapter 5 References
     [doi:10.1109/TSE.1983.236733](http://dx.doi.org/10.1109/TSE.1983.236733)
 
 1.  Nuno Preguiça, Carlos Baquero, Paulo Sérgio
-    Almeida, et al.: “[Dotted Version Vectors: Logical Clocks for Optimistic Replication](http://arxiv.org/pdf/1011.5808v1.pdf),” arXiv:1011.5808, November 26,
-    2010.
+    Almeida, et al.: “[Dotted Version Vectors: Logical Clocks for Optimistic Replication](http://arxiv.org/pdf/1011.5808v1.pdf),” arXiv:1011.5808, November 26, 2010.
 
 1.  Sean Cribbs:
     “[A Brief History of Time in Riak](https://speakerdeck.com/seancribbs/a-brief-history-of-time-in-riak),”

--- a/chapter-05-refs.md
+++ b/chapter-05-refs.md
@@ -39,10 +39,10 @@ Chapter 5 References
     “[Windows Azure Storage](https://www.umbrant.com/2016/02/04/windows-azure-storage/),”
     *umbrant.com*, February 4, 2016.
 
-1.  “[Percona    Xtrabackup - Documentation](https://www.percona.com/doc/percona-xtrabackup/2.1/index.html),” Percona LLC, 2014.
+1.  “[Percona Xtrabackup - Documentation](https://www.percona.com/doc/percona-xtrabackup/2.1/index.html),” Percona LLC, 2014.
 
 1.  Jesse Newland:
-      “[GitHub Availability This   Week](https://github.com/blog/1261-github-availability-this-week),” *github.com*, September 14, 2012.
+      “[GitHub Availability This Week](https://github.com/blog/1261-github-availability-this-week),” *github.com*, September 14, 2012.
 
 1.  Mark Imbriaco:
       “[Downtime Last Saturday](https://github.com/blog/1364-downtime-last-saturday),”
@@ -128,21 +128,21 @@ Chapter 5 References
     Systems Principles* (SOSP), October 2007.
 
 1.  Marc Shapiro, Nuno Preguiça, Carlos Baquero,
-      and Marek Zawirski: “[A Comprehensive Study of   Convergent and Commutative Replicated Data Types](http://hal.inria.fr/inria-00555588/),” INRIA Research Report no. 7506,
+      and Marek Zawirski: “[A Comprehensive Study of Convergent and Commutative Replicated Data Types](http://hal.inria.fr/inria-00555588/),” INRIA Research Report no. 7506,
       January 2011.
 
 1.  Sam Elliott:
-      “[CRDTs: An UPDATE (or   Maybe Just a PUT)](https://speakerdeck.com/lenary/crdts-an-update-or-just-a-put),” at *RICON West*, October 2013.
+      “[CRDTs: An UPDATE (or Maybe Just a PUT)](https://speakerdeck.com/lenary/crdts-an-update-or-just-a-put),” at *RICON West*, October 2013.
 
 1.  Russell Brown:
-      “[A Bluffers Guide to CRDTs in   Riak](https://gist.github.com/russelldb/f92f44bdfb619e089a4d),” *gist.github.com*, October 28, 2013.
+      “[A Bluffers Guide to CRDTs in Riak](https://gist.github.com/russelldb/f92f44bdfb619e089a4d),” *gist.github.com*, October 28, 2013.
 
 1.  Benjamin Farinier, Thomas Gazagnaire, and
-      Anil Madhavapeddy: “[Mergeable Persistent Data   Structures](http://gazagnaire.org/pub/FGM15.pdf),” at *26es Journées Francophones des Langages Applicatifs* (JFLA),
+      Anil Madhavapeddy: “[Mergeable Persistent Data Structures](http://gazagnaire.org/pub/FGM15.pdf),” at *26es Journées Francophones des Langages Applicatifs* (JFLA),
       January 2015.
 
 1.  Chengzheng Sun and Clarence Ellis:
-      “[Operational   Transformation in Real-Time Group Editors: Issues, Algorithms, and Achievements](http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.53.933&rep=rep1&type=pdf),” at
+      “[Operational Transformation in Real-Time Group Editors: Issues, Algorithms, and Achievements](http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.53.933&rep=rep1&type=pdf),” at
       *ACM Conference on Computer Supported Cooperative Work* (CSCW), November 1998.
 
 1.  Lars Hofhansl:

--- a/chapter-05-refs.md
+++ b/chapter-05-refs.md
@@ -217,4 +217,3 @@ Chapter 5 References
     “[Detecting Causal Relationships in Distributed Computations: In Search of the Holy Grail](http://dcg.ethz.ch/lectures/hs08/seminar/papers/mattern4.pdf),” *Distributed
     Computing*, volume 7, number 3, pages 149–174, March 1994.
     [doi:10.1007/BF02277859](http://dx.doi.org/10.1007/BF02277859)
-

--- a/chapter-06-refs.md
+++ b/chapter-06-refs.md
@@ -109,4 +109,3 @@ Chapter 6 References
     “[Massively Parallel Databases and MapReduce Systems](https://www.microsoft.com/en-us/research/wp-content/uploads/2013/11/db-mr-survey-final.pdf),”
     *Foundations and Trends in Databases*, volume 5, number 1, pages 1–104, November 2013.
     [doi:10.1561/1900000036](http://dx.doi.org/10.1561/1900000036)
-

--- a/chapter-07-refs.md
+++ b/chapter-07-refs.md
@@ -69,8 +69,7 @@ Chapter 7 References
 1.  Chris Siebenmann:
     “[Unix's File Durability Problem](https://utcc.utoronto.ca/~cks/space/blog/unix/FileSyncProblem),” *utcc.utoronto.ca*, April 14, 2016.
 
-1.  Lakshmi N. Bairavasundaram, Garth R.
-    Goodson, Bianca Schroeder, et al.:
+1.  Lakshmi N. Bairavasundaram, Garth R. Goodson, Bianca Schroeder, et al.:
     “[An Analysis of Data Corruption in the Storage Stack](http://research.cs.wisc.edu/adsl/Publications/corruption-fast08.pdf),” at *6th USENIX Conference on File and Storage
     Technologies* (FAST), February 2008.
 

--- a/chapter-07-refs.md
+++ b/chapter-07-refs.md
@@ -212,4 +212,3 @@ Chapter 7 References
 1.  Dave Rosenthal:
     “[Databases at 14.4MHz](http://web.archive.org/web/20150427041746/http://blog.foundationdb.com/databases-at-14.4mhz),”
     *blog.foundationdb.com*, December 10, 2014.
-

--- a/chapter-07-refs.md
+++ b/chapter-07-refs.md
@@ -75,7 +75,7 @@ Chapter 7 References
       Technologies* (FAST), February 2008.
 
 1.  Bianca Schroeder, Raghav Lagisetty, and Arif Merchant:
-      “[Flash   Reliability in Production: The Expected and the Unexpected](https://www.usenix.org/conference/fast16/technical-sessions/presentation/schroeder),” at *14th USENIX Conference on
+      “[Flash Reliability in Production: The Expected and the Unexpected](https://www.usenix.org/conference/fast16/technical-sessions/presentation/schroeder),” at *14th USENIX Conference on
       File and Storage Technologies* (FAST), February 2016.
 
 1.  Don Allison:

--- a/chapter-07-refs.md
+++ b/chapter-07-refs.md
@@ -51,35 +51,35 @@ Chapter 7 References
     [doi:10.1145/1071610.1071615](http://dx.doi.org/10.1145/1071610.1071615)
 
 1.  Mai Zheng, Joseph Tucek, Feng Qin, and Mark Lillibridge:
-      “[Understanding the Robustness of SSDs Under Power Fault](https://www.usenix.org/system/files/conference/fast13/fast13-final80.pdf),” at *11th USENIX Conference on File and
-      Storage Technologies* (FAST), February 2013.
+    “[Understanding the Robustness of SSDs Under Power Fault](https://www.usenix.org/system/files/conference/fast13/fast13-final80.pdf),” at *11th USENIX Conference on File and
+    Storage Technologies* (FAST), February 2013.
 
 1.  Laurie Denness:
-      “[SSDs: A Gift and a Curse](https://laur.ie/blog/2015/06/ssds-a-gift-and-a-curse/),”
-      *laur.ie*, June 2, 2015.
+    “[SSDs: A Gift and a Curse](https://laur.ie/blog/2015/06/ssds-a-gift-and-a-curse/),”
+    *laur.ie*, June 2, 2015.
 
 1.  Adam Surak:
-      “[When Solid State Drives Are Not That Solid](https://blog.algolia.com/when-solid-state-drives-are-not-that-solid/),” *blog.algolia.com*, June 15, 2015.
+    “[When Solid State Drives Are Not That Solid](https://blog.algolia.com/when-solid-state-drives-are-not-that-solid/),” *blog.algolia.com*, June 15, 2015.
 
 1.  Thanumalayan Sankaranarayana Pillai, Vijay Chidambaram,
-      Ramnatthan Alagappan, et al.: “[All File Systems Are Not Created Equal: On the Complexity of Crafting Crash-Consistent Applications](http://research.cs.wisc.edu/wind/Publications/alice-osdi14.pdf),”
-      at *11th USENIX Symposium on Operating Systems Design and Implementation* (OSDI),
-      October 2014.
+    Ramnatthan Alagappan, et al.: “[All File Systems Are Not Created Equal: On the Complexity of Crafting Crash-Consistent Applications](http://research.cs.wisc.edu/wind/Publications/alice-osdi14.pdf),”
+    at *11th USENIX Symposium on Operating Systems Design and Implementation* (OSDI),
+    October 2014.
 
 1.  Chris Siebenmann:
-      “[Unix's File Durability Problem](https://utcc.utoronto.ca/~cks/space/blog/unix/FileSyncProblem),” *utcc.utoronto.ca*, April 14, 2016.
+    “[Unix's File Durability Problem](https://utcc.utoronto.ca/~cks/space/blog/unix/FileSyncProblem),” *utcc.utoronto.ca*, April 14, 2016.
 
 1.  Lakshmi N. Bairavasundaram, Garth R.
-      Goodson, Bianca Schroeder, et al.:
-      “[An Analysis of Data Corruption in the Storage Stack](http://research.cs.wisc.edu/adsl/Publications/corruption-fast08.pdf),” at *6th USENIX Conference on File and Storage
-      Technologies* (FAST), February 2008.
+    Goodson, Bianca Schroeder, et al.:
+    “[An Analysis of Data Corruption in the Storage Stack](http://research.cs.wisc.edu/adsl/Publications/corruption-fast08.pdf),” at *6th USENIX Conference on File and Storage
+    Technologies* (FAST), February 2008.
 
 1.  Bianca Schroeder, Raghav Lagisetty, and Arif Merchant:
-      “[Flash Reliability in Production: The Expected and the Unexpected](https://www.usenix.org/conference/fast16/technical-sessions/presentation/schroeder),” at *14th USENIX Conference on
-      File and Storage Technologies* (FAST), February 2016.
+    “[Flash Reliability in Production: The Expected and the Unexpected](https://www.usenix.org/conference/fast16/technical-sessions/presentation/schroeder),” at *14th USENIX Conference on
+    File and Storage Technologies* (FAST), February 2016.
 
 1.  Don Allison:
-      “[SSD Storage – Ignorance of Technology Is No Excuse](https://blog.korelogic.com/blog/2015/03/24),” *blog.korelogic.com*, March 24, 2015.
+    “[SSD Storage – Ignorance of Technology Is No Excuse](https://blog.korelogic.com/blog/2015/03/24),” *blog.korelogic.com*, March 24, 2015.
 
 1.  Dave Scherer:
     “[Those Are Not Transactions (Cassandra 2.0)](http://web.archive.org/web/20150526065247/http://blog.foundationdb.com/those-are-not-transactions-cassandra-2-0),” *blog.foundationdb.com*, September 6, 2013.
@@ -164,15 +164,15 @@ Chapter 7 References
     at *38th International Conference on Very Large Databases* (VLDB), August 2012.
 
 1.  Tony Andrews:
-      “[Enforcing Complex Constraints in Oracle](http://tonyandrews.blogspot.co.uk/2004/10/enforcing-complex-constraints-in.html),” *tonyandrews.blogspot.co.uk*, October 15, 2004.
+    “[Enforcing Complex Constraints in Oracle](http://tonyandrews.blogspot.co.uk/2004/10/enforcing-complex-constraints-in.html),” *tonyandrews.blogspot.co.uk*, October 15, 2004.
 
 1.  Douglas B. Terry, Marvin M. Theimer, Karin Petersen, et al.:
-      “[Managing Update Conflicts in Bayou, a Weakly Connected Replicated Storage System](https://citeseerx.ist.psu.edu/pdf/20c450f099b661c5a2dff3f348773a0d1af1b09b),” at
-      *15th ACM Symposium on Operating Systems Principles* (SOSP), December 1995.
-      [doi:10.1145/224056.224070](http://dx.doi.org/10.1145/224056.224070)
+    “[Managing Update Conflicts in Bayou, a Weakly Connected Replicated Storage System](https://citeseerx.ist.psu.edu/pdf/20c450f099b661c5a2dff3f348773a0d1af1b09b),” at
+    *15th ACM Symposium on Operating Systems Principles* (SOSP), December 1995.
+    [doi:10.1145/224056.224070](http://dx.doi.org/10.1145/224056.224070)
 
 1.  Gary Fredericks:
-      “[Postgres Serializability Bug](https://github.com/gfredericks/pg-serializability-bug),” *github.com*, September 2015.
+    “[Postgres Serializability Bug](https://github.com/gfredericks/pg-serializability-bug),” *github.com*, September 2015.
 
 1.  Michael Stonebraker, Samuel Madden, Daniel J. Abadi, et al.:
     “[The End of an Architectural Era (It’s Time for a Complete Rewrite)](https://citeseerx.ist.psu.edu/pdf/775d54c66d271028a7d4dadf07cce6f918584cd3),” at *33rd International

--- a/chapter-08-refs.md
+++ b/chapter-08-refs.md
@@ -328,8 +328,8 @@ Chapter 8 References
     “[The Discovery of Apache ZooKeeper’s Poison Packet](http://www.pagerduty.com/blog/the-discovery-of-apache-zookeepers-poison-packet/),” *pagerduty.com*, May 7, 2015.
 
 1.  Jonathan Stone and Craig Partridge:
-    “[When the CRC and TCP Checksum Disagree](https://web.archive.org/web/20220818235232/https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.27.7611&rep=rep1&type=pdf),” at *ACM Conference on Applications,
-    Technologies, Architectures, and Protocols for Computer Communication* (SIGCOMM), August 2000.
+    “[When the CRC and TCP Checksum Disagree](https://web.archive.org/web/20220818235232/https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.27.7611&rep=rep1&type=pdf),”
+    at *ACM Conference on Applications, Technologies, Architectures, and Protocols for Computer Communication* (SIGCOMM), August 2000.
     [doi:10.1145/347059.347561](http://dx.doi.org/10.1145/347059.347561)
 
 1.  Evan Jones:

--- a/chapter-08-refs.md
+++ b/chapter-08-refs.md
@@ -12,8 +12,7 @@ Chapter 8 References
     “[Getting Real About Distributed System Reliability](http://blog.empathybox.com/post/19574936361/getting-real-about-distributed-system-reliability),” *blog.empathybox.com*, March 19, 2012.
 
 1.  Sydney Padua: *The Thrilling Adventures of
-    Lovelace and Babbage: The (Mostly) True Story of the First Computer*. Particular Books, April
-    2015.  ISBN: 978-0-141-98151-2
+    Lovelace and Babbage: The (Mostly) True Story of the First Computer*. Particular Books, April 2015.  ISBN: 978-0-141-98151-2
 
 1.  Coda Hale:
     “[You Can’t Sacrifice Partition Tolerance](http://codahale.com/you-cant-sacrifice-partition-tolerance/),” *codahale.com*, October 7, 2010.

--- a/chapter-08-refs.md
+++ b/chapter-08-refs.md
@@ -371,4 +371,3 @@ Chapter 8 References
     “[Scalability! But at What COST?](http://www.frankmcsherry.org/assets/COST.pdf),”
     at *15th USENIX Workshop on Hot Topics in Operating Systems* (HotOS),
     May 2015.
-

--- a/chapter-08-refs.md
+++ b/chapter-08-refs.md
@@ -77,8 +77,7 @@ Chapter 8 References
     *github.com*, December 26, 2012.
 
 1.  Will Oremus:
-    “[The Global Internet Is Being Attacked by Sharks, Google Confirms](http://www.slate.com/blogs/future_tense/2014/08/15/shark_attacks_threaten_google_s_undersea_internet_cables_video.html),” *slate.com*, August 15,
-    2014.
+    “[The Global Internet Is Being Attacked by Sharks, Google Confirms](http://www.slate.com/blogs/future_tense/2014/08/15/shark_attacks_threaten_google_s_undersea_internet_cables_video.html),” *slate.com*, August 15, 2014.
 
 1.  Marc A. Donges:
     “[Re: bnx2 cards Intermittantly Going Offline](http://www.spinics.net/lists/netdev/msg210485.html),” Message to Linux *netdev* mailing list, *spinics.net*, September 13, 2012.
@@ -265,8 +264,7 @@ Chapter 8 References
     “[fsyncers and Curveballs](https://web.archive.org/web/20220107141023/http://shaver.off.net/diary/2008/05/25/fsyncers-and-curveballs/),” *shaver.off.net*, May 25, 2008.
 
 1.  Zhenyun Zhuang and Cuong Tran:
-    “[Eliminating Large JVM GC Pauses Caused by Background IO Traffic](https://engineering.linkedin.com/blog/2016/02/eliminating-large-jvm-gc-pauses-caused-by-background-io-traffic),” *engineering.linkedin.com*, February 10,
-    2016.
+    “[Eliminating Large JVM GC Pauses Caused by Background IO Traffic](https://engineering.linkedin.com/blog/2016/02/eliminating-large-jvm-gc-pauses-caused-by-background-io-traffic),” *engineering.linkedin.com*, February 10, 2016.
 
 1.  David Terei and Amit Levy:
     “[Blade: A Data Center Garbage Collector](http://arxiv.org/pdf/1504.02578.pdf),”

--- a/chapter-08-refs.md
+++ b/chapter-08-refs.md
@@ -22,7 +22,7 @@ Chapter 8 References
     “[Notes on Distributed Systems for Young Bloods](https://web.archive.org/web/20200218095605/https://www.somethingsimilar.com/2013/01/14/notes-on-distributed-systems-for-young-bloods/),” *somethingsimilar.com*, January 14, 2013.
 
 1.  Antonio Regalado:
-      “[Who Coined 'Cloud Computing'?](https://www.technologyreview.com/2011/10/31/257406/who-coined-cloud-computing/),” *technologyreview.com*, October 31, 2011.
+    “[Who Coined 'Cloud Computing'?](https://www.technologyreview.com/2011/10/31/257406/who-coined-cloud-computing/),” *technologyreview.com*, October 31, 2011.
 
 1.  Luiz André Barroso, Jimmy Clidaras, and Urs Hölzle:
     “[The Datacenter as a Computer: An Introduction to the Design of Warehouse-Scale Machines, Second Edition](https://web.archive.org/web/20140404113735/http://www.morganclaypool.com/doi/abs/10.2200/S00516ED2V01Y201306CAC024),”
@@ -37,12 +37,12 @@ Chapter 8 References
     Analysis* (SC12), November 2012.
 
 1.  Arjun Singh, Joon Ong, Amit Agarwal, et al.:
-      “[Jupiter Rising: A Decade of Clos Topologies and Centralized Control in Google’s Datacenter Network](http://conferences.sigcomm.org/sigcomm/2015/pdf/papers/p183.pdf),” at
-      *Annual Conference of the ACM Special Interest Group on Data Communication* (SIGCOMM), August 2015.
-      [doi:10.1145/2785956.2787508](http://dx.doi.org/10.1145/2785956.2787508)
+    “[Jupiter Rising: A Decade of Clos Topologies and Centralized Control in Google’s Datacenter Network](http://conferences.sigcomm.org/sigcomm/2015/pdf/papers/p183.pdf),” at
+    *Annual Conference of the ACM Special Interest Group on Data Communication* (SIGCOMM), August 2015.
+    [doi:10.1145/2785956.2787508](http://dx.doi.org/10.1145/2785956.2787508)
 
 1.  Glenn K. Lockwood:
-      “[Hadoop's Uncomfortable Fit in HPC](http://glennklockwood.blogspot.co.uk/2014/05/hadoops-uncomfortable-fit-in-hpc.html),” *glennklockwood.blogspot.co.uk*, May 16, 2014.
+    “[Hadoop's Uncomfortable Fit in HPC](http://glennklockwood.blogspot.co.uk/2014/05/hadoops-uncomfortable-fit-in-hpc.html),” *glennklockwood.blogspot.co.uk*, May 16, 2014.
 
 1.  John von Neumann:
     “[Probabilistic Logics and the Synthesis of Reliable Organisms from Unreliable Components](https://personalpages.manchester.ac.uk/staff/nikolaos.kyparissas/uploads/VonNeumann1956.pdf),” in *Automata Studies (AM-34)*,
@@ -50,8 +50,8 @@ Chapter 8 References
     ISBN: 978-0-691-07916-5
 
 1.  Richard W. Hamming:
-      *The Art of Doing Science and Engineering*. Taylor & Francis, 1997.
-      ISBN: 978-9-056-99500-3
+    *The Art of Doing Science and Engineering*. Taylor & Francis, 1997.
+    ISBN: 978-9-056-99500-3
 
 1.  Claude E. Shannon:
     “[A Mathematical Theory of Communication](http://cs.brynmawr.edu/Courses/cs380/fall2012/shannon1948.pdf),” *The Bell System Technical Journal*, volume 27, number 3,
@@ -90,11 +90,11 @@ Chapter 8 References
     “[A Few Arguments About Redis Sentinel Properties and Fail Scenarios](http://antirez.com/news/80),” *antirez.com*, October 21, 2014.
 
 1.  Bert Hubert:
-      “[The Ultimate SO_LINGER Page, or: Why Is My TCP Not Reliable](http://blog.netherlabs.nl/articles/2009/01/18/the-ultimate-so_linger-page-or-why-is-my-tcp-not-reliable),” *blog.netherlabs.nl*, January 18, 2009.
+    “[The Ultimate SO_LINGER Page, or: Why Is My TCP Not Reliable](http://blog.netherlabs.nl/articles/2009/01/18/the-ultimate-so_linger-page-or-why-is-my-tcp-not-reliable),” *blog.netherlabs.nl*, January 18, 2009.
 
 1.  Nicolas Liochon:
-      “[CAP:   If All You Have Is a Timeout, Everything Looks Like a Partition](http://blog.thislongrun.com/2015/05/CAP-theorem-partition-timeout-zookeeper.html),” *blog.thislongrun.com*,
-      May 25, 2015.
+    “[CAP:   If All You Have Is a Timeout, Everything Looks Like a Partition](http://blog.thislongrun.com/2015/05/CAP-theorem-partition-timeout-zookeeper.html),” *blog.thislongrun.com*,
+    May 25, 2015.
 
 1.  Jerome H. Saltzer, David P. Reed, and David D. Clark:
     “[End-To-End Arguments in System Design](https://groups.csail.mit.edu/ana/Publications/PubPDFs/End-to-End%20Arguments%20in%20System%20Design.pdf),”
@@ -106,14 +106,14 @@ Chapter 8 References
     Systems Design and Implementation* (NSDI), May 2015.
 
 1.  Guohui Wang and T. S. Eugene Ng:
-      “[The Impact of Virtualization on Network Performance of Amazon EC2 Data Center](http://www.cs.rice.edu/~eugeneng/papers/INFOCOM10-ec2.pdf),” at *29th IEEE
-      International Conference on Computer Communications* (INFOCOM), March 2010.
-      [doi:10.1109/INFCOM.2010.5461931](http://dx.doi.org/10.1109/INFCOM.2010.5461931)
+    “[The Impact of Virtualization on Network Performance of Amazon EC2 Data Center](http://www.cs.rice.edu/~eugeneng/papers/INFOCOM10-ec2.pdf),” at *29th IEEE
+    International Conference on Computer Communications* (INFOCOM), March 2010.
+    [doi:10.1109/INFCOM.2010.5461931](http://dx.doi.org/10.1109/INFCOM.2010.5461931)
 
 1.  Van Jacobson:
-      “[Congestion Avoidance and Control](http://www.cs.usask.ca/ftp/pub/discus/seminars2002-2003/p314-jacobson.pdf),” at *ACM Symposium on Communications Architectures and
-      Protocols* (SIGCOMM), August 1988.
-      [doi:10.1145/52324.52356](http://dx.doi.org/10.1145/52324.52356)
+    “[Congestion Avoidance and Control](http://www.cs.usask.ca/ftp/pub/discus/seminars2002-2003/p314-jacobson.pdf),” at *ACM Symposium on Communications Architectures and
+    Protocols* (SIGCOMM), August 1988.
+    [doi:10.1145/52324.52356](http://dx.doi.org/10.1145/52324.52356)
 
 1.  Brandon Philips:
     “[etcd: Distributed Locking and Service Discovery](https://www.youtube.com/watch?v=HJIjTTHWYnE),” at *Strange Loop*, September 2014.
@@ -161,38 +161,38 @@ Chapter 8 References
     “[Time on Multi-Core, Multi-Socket Servers](http://steveloughran.blogspot.co.uk/2015/09/time-on-multi-core-multi-socket-servers.html),” *steveloughran.blogspot.co.uk*, September 17, 2015.
 
 1.  James C. Corbett, Jeffrey Dean, Michael Epstein, et al.:
-      “[Spanner: Google’s Globally-Distributed Database](https://research.google/pubs/pub39966/),” at *10th USENIX Symposium on Operating System Design and
-      Implementation* (OSDI), October 2012.
+    “[Spanner: Google’s Globally-Distributed Database](https://research.google/pubs/pub39966/),” at *10th USENIX Symposium on Operating System Design and
+    Implementation* (OSDI), October 2012.
 
 1.  M. Caporaloni and R. Ambrosini:
-      “[How Closely Can a Personal Computer Clock Track the UTC Timescale Via the Internet?](https://iopscience.iop.org/0143-0807/23/4/103/),” *European Journal of
-      Physics*, volume 23, number 4, pages L17–L21, June 2012.
-      [doi:10.1088/0143-0807/23/4/103](http://dx.doi.org/10.1088/0143-0807/23/4/103)
+    “[How Closely Can a Personal Computer Clock Track the UTC Timescale Via the Internet?](https://iopscience.iop.org/0143-0807/23/4/103/),” *European Journal of
+    Physics*, volume 23, number 4, pages L17–L21, June 2012.
+    [doi:10.1088/0143-0807/23/4/103](http://dx.doi.org/10.1088/0143-0807/23/4/103)
 
 1.  Nelson Minar:
-      “[A Survey of the NTP Network](http://alumni.media.mit.edu/~nelson/research/ntp-survey99/),”
-      *alumni.media.mit.edu*, December 1999.
+    “[A Survey of the NTP Network](http://alumni.media.mit.edu/~nelson/research/ntp-survey99/),”
+    *alumni.media.mit.edu*, December 1999.
 
 1.  Viliam Holub:
-      “[Synchronizing Clocks in a Cassandra Cluster Pt. 1 – The Problem](https://blog.rapid7.com/2014/03/14/synchronizing-clocks-in-a-cassandra-cluster-pt-1-the-problem/),” *blog.rapid7.com*, March 14, 2014.
+    “[Synchronizing Clocks in a Cassandra Cluster Pt. 1 – The Problem](https://blog.rapid7.com/2014/03/14/synchronizing-clocks-in-a-cassandra-cluster-pt-1-the-problem/),” *blog.rapid7.com*, March 14, 2014.
 
 1.  Poul-Henning Kamp:
-      “[The One-Second War (What Time Will You Die?)](http://queue.acm.org/detail.cfm?id=1967009),” *ACM Queue*, volume 9, number 4, pages 44–48, April 2011.
-      [doi:10.1145/1966989.1967009](http://dx.doi.org/10.1145/1966989.1967009)
+    “[The One-Second War (What Time Will You Die?)](http://queue.acm.org/detail.cfm?id=1967009),” *ACM Queue*, volume 9, number 4, pages 44–48, April 2011.
+    [doi:10.1145/1966989.1967009](http://dx.doi.org/10.1145/1966989.1967009)
 
 1.  Nelson Minar:
-      “[Leap Second Crashes Half the Internet](http://www.somebits.com/weblog/tech/bad/leap-second-2012.html),” *somebits.com*, July 3, 2012.
+    “[Leap Second Crashes Half the Internet](http://www.somebits.com/weblog/tech/bad/leap-second-2012.html),” *somebits.com*, July 3, 2012.
 
 1.  Christopher Pascoe:
-      “[Time,   Technology and Leaping Seconds](http://googleblog.blogspot.co.uk/2011/09/time-technology-and-leaping-seconds.html),” *googleblog.blogspot.co.uk*, September 15, 2011.
+    “[Time,   Technology and Leaping Seconds](http://googleblog.blogspot.co.uk/2011/09/time-technology-and-leaping-seconds.html),” *googleblog.blogspot.co.uk*, September 15, 2011.
 
 1.  Mingxue Zhao and Jeff Barr:
-      “[Look Before You Leap – The Coming Leap Second and AWS](https://aws.amazon.com/blogs/aws/look-before-you-leap-the-coming-leap-second-and-aws/),” *aws.amazon.com*, May 18, 2015.
+    “[Look Before You Leap – The Coming Leap Second and AWS](https://aws.amazon.com/blogs/aws/look-before-you-leap-the-coming-leap-second-and-aws/),” *aws.amazon.com*, May 18, 2015.
 
 1.  Darryl Veitch and Kanthaiah Vijayalayan:
-      “[Network Timing and the 2015 Leap Second](https://tklab.feit.uts.edu.au/~darryl/Publications/LeapSecond_camera.pdf),” at *17th International Conference on Passive and Active
-      Measurement* (PAM), April 2016.
-      [doi:10.1007/978-3-319-30505-9_29](http://dx.doi.org/10.1007/978-3-319-30505-9_29)
+    “[Network Timing and the 2015 Leap Second](https://tklab.feit.uts.edu.au/~darryl/Publications/LeapSecond_camera.pdf),” at *17th International Conference on Passive and Active
+    Measurement* (PAM), April 2016.
+    [doi:10.1007/978-3-319-30505-9_29](http://dx.doi.org/10.1007/978-3-319-30505-9_29)
 
 1.  “[Timekeeping in VMware Virtual Machines](https://www.vmware.com/content/dam/digitalmarketing/vmware/en/pdf/techpaper/Timekeeping-In-VirtualMachines.pdf),”
     Information Guide, VMware, Inc., December 2011.
@@ -212,7 +212,7 @@ Chapter 8 References
     *riak.com*, November 12, 2013.
 
 1.  Kyle Kingsbury:
-      “[The Trouble with Timestamps](https://aphyr.com/posts/299-the-trouble-with-timestamps),” *aphyr.com*, October 12, 2013.
+    “[The Trouble with Timestamps](https://aphyr.com/posts/299-the-trouble-with-timestamps),” *aphyr.com*, October 12, 2013.
 
 1.  Leslie Lamport:
     “[Time, Clocks, and the Ordering of Events in a Distributed System](https://www.microsoft.com/en-us/research/publication/time-clocks-ordering-events-distributed-system/),”
@@ -247,26 +247,26 @@ Chapter 8 References
     [doi:10.1145/74850.74870](http://dx.doi.org/10.1145/74850.74870)
 
 1.  Todd Lipcon:
-      “[Avoiding Full GCs in Apache HBase with MemStore-Local Allocation Buffers: Part 1](https://web.archive.org/web/20121101040711/http://blog.cloudera.com/blog/2011/02/avoiding-full-gcs-in-hbase-with-memstore-local-allocation-buffers-part-1/),”
-      *blog.cloudera.com*, February 24, 2011.
+    “[Avoiding Full GCs in Apache HBase with MemStore-Local Allocation Buffers: Part 1](https://web.archive.org/web/20121101040711/http://blog.cloudera.com/blog/2011/02/avoiding-full-gcs-in-hbase-with-memstore-local-allocation-buffers-part-1/),”
+    *blog.cloudera.com*, February 24, 2011.
 
 1.  Martin Thompson:
-      “[Java Garbage Collection Distilled](http://mechanical-sympathy.blogspot.co.uk/2013/07/java-garbage-collection-distilled.html),” *mechanical-sympathy.blogspot.co.uk*, July 16, 2013.
+    “[Java Garbage Collection Distilled](http://mechanical-sympathy.blogspot.co.uk/2013/07/java-garbage-collection-distilled.html),” *mechanical-sympathy.blogspot.co.uk*, July 16, 2013.
 
 1.  Alexey Ragozin:
-      “[How to Tame Java GC Pauses? Surviving 16GiB Heap and Greater](https://dzone.com/articles/how-tame-java-gc-pauses),”
-      *dzone.com*, June 28, 2011.
+    “[How to Tame Java GC Pauses? Surviving 16GiB Heap and Greater](https://dzone.com/articles/how-tame-java-gc-pauses),”
+    *dzone.com*, June 28, 2011.
 
 1.  Christopher Clark, Keir Fraser, Steven Hand, et al.:
-      “[Live Migration of Virtual Machines](http://www.cl.cam.ac.uk/research/srg/netos/papers/2005-nsdi-migration.pdf),” at *2nd USENIX Symposium on Symposium on
-      Networked Systems Design & Implementation* (NSDI), May 2005.
+    “[Live Migration of Virtual Machines](http://www.cl.cam.ac.uk/research/srg/netos/papers/2005-nsdi-migration.pdf),” at *2nd USENIX Symposium on Symposium on
+    Networked Systems Design & Implementation* (NSDI), May 2005.
 
 1.  Mike Shaver:
-      “[fsyncers and Curveballs](https://web.archive.org/web/20220107141023/http://shaver.off.net/diary/2008/05/25/fsyncers-and-curveballs/),” *shaver.off.net*, May 25, 2008.
+    “[fsyncers and Curveballs](https://web.archive.org/web/20220107141023/http://shaver.off.net/diary/2008/05/25/fsyncers-and-curveballs/),” *shaver.off.net*, May 25, 2008.
 
 1.  Zhenyun Zhuang and Cuong Tran:
-      “[Eliminating Large JVM GC Pauses Caused by Background IO Traffic](https://engineering.linkedin.com/blog/2016/02/eliminating-large-jvm-gc-pauses-caused-by-background-io-traffic),” *engineering.linkedin.com*, February 10,
-      2016.
+    “[Eliminating Large JVM GC Pauses Caused by Background IO Traffic](https://engineering.linkedin.com/blog/2016/02/eliminating-large-jvm-gc-pauses-caused-by-background-io-traffic),” *engineering.linkedin.com*, February 10,
+    2016.
 
 1.  David Terei and Amit Levy:
     “[Blade: A Data Center Garbage Collector](http://arxiv.org/pdf/1504.02578.pdf),”
@@ -313,34 +313,34 @@ Chapter 8 References
     `allla-mport-spubso-ntheweb`.
 
 1.  John Rushby:
-      “[Bus Architectures for Safety-Critical Embedded Systems](http://www.csl.sri.com/papers/emsoft01/emsoft01.pdf),” at *1st International Workshop on Embedded Software*
-      (EMSOFT), October 2001.
+    “[Bus Architectures for Safety-Critical Embedded Systems](http://www.csl.sri.com/papers/emsoft01/emsoft01.pdf),” at *1st International Workshop on Embedded Software*
+    (EMSOFT), October 2001.
 
 1.  Jake Edge:
-      “[ELC: SpaceX Lessons Learned](http://lwn.net/Articles/540368/),” *lwn.net*,
-      March 6, 2013.
+    “[ELC: SpaceX Lessons Learned](http://lwn.net/Articles/540368/),” *lwn.net*,
+    March 6, 2013.
 
 1.  Andrew Miller and Joseph J. LaViola, Jr.:
-      “[Anonymous Byzantine Consensus from Moderately-Hard Puzzles: A Model for Bitcoin](http://nakamotoinstitute.org/static/docs/anonymous-byzantine-consensus.pdf),” University of Central
-      Florida, Technical Report CS-TR-14-01, April 2014.
+    “[Anonymous Byzantine Consensus from Moderately-Hard Puzzles: A Model for Bitcoin](http://nakamotoinstitute.org/static/docs/anonymous-byzantine-consensus.pdf),” University of Central
+    Florida, Technical Report CS-TR-14-01, April 2014.
 
 1.  James Mickens:
     “[The Saddest Moment](https://www.usenix.org/system/files/login-logout_1305_mickens.pdf),” *USENIX ;login: logout*, May 2013.
 
 1.  Evan Gilman:
-      “[The Discovery of Apache ZooKeeper’s Poison Packet](http://www.pagerduty.com/blog/the-discovery-of-apache-zookeepers-poison-packet/),” *pagerduty.com*, May 7, 2015.
+    “[The Discovery of Apache ZooKeeper’s Poison Packet](http://www.pagerduty.com/blog/the-discovery-of-apache-zookeepers-poison-packet/),” *pagerduty.com*, May 7, 2015.
 
 1.  Jonathan Stone and Craig Partridge:
-      “[When the CRC and TCP Checksum Disagree](https://web.archive.org/web/20220818235232/https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.27.7611&rep=rep1&type=pdf),” at *ACM Conference on Applications,
-      Technologies, Architectures, and Protocols for Computer Communication* (SIGCOMM), August 2000.
-      [doi:10.1145/347059.347561](http://dx.doi.org/10.1145/347059.347561)
+    “[When the CRC and TCP Checksum Disagree](https://web.archive.org/web/20220818235232/https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.27.7611&rep=rep1&type=pdf),” at *ACM Conference on Applications,
+    Technologies, Architectures, and Protocols for Computer Communication* (SIGCOMM), August 2000.
+    [doi:10.1145/347059.347561](http://dx.doi.org/10.1145/347059.347561)
 
 1.  Evan Jones:
-      “[How Both TCP and Ethernet Checksums Fail](http://www.evanjones.ca/tcp-and-ethernet-checksums-fail.html),” *evanjones.ca*, October 5, 2015.
+    “[How Both TCP and Ethernet Checksums Fail](http://www.evanjones.ca/tcp-and-ethernet-checksums-fail.html),” *evanjones.ca*, October 5, 2015.
 
 1.  Cynthia Dwork, Nancy Lynch, and Larry Stockmeyer:
-      “[Consensus in the Presence of Partial Synchrony](https://dl.acm.org/doi/10.1145/42282.42283),” *Journal of the ACM*, volume 35, number 2, pages 288–323,
-      April 1988. [doi:10.1145/42282.42283](http://dx.doi.org/10.1145/42282.42283)
+    “[Consensus in the Presence of Partial Synchrony](https://dl.acm.org/doi/10.1145/42282.42283),” *Journal of the ACM*, volume 35, number 2, pages 288–323,
+    April 1988. [doi:10.1145/42282.42283](http://dx.doi.org/10.1145/42282.42283)
 
 1.  Peter Bailis and Ali Ghodsi:
     “[Eventual Consistency Today: Limitations, Extensions, and Beyond](http://queue.acm.org/detail.cfm?id=2462076),” *ACM Queue*, volume 11, number 3, pages 55-63, March 2013.

--- a/chapter-08-refs.md
+++ b/chapter-08-refs.md
@@ -12,7 +12,7 @@ Chapter 8 References
     “[Getting Real About Distributed System Reliability](http://blog.empathybox.com/post/19574936361/getting-real-about-distributed-system-reliability),” *blog.empathybox.com*, March 19, 2012.
 
 1.  Sydney Padua: *The Thrilling Adventures of
-    Lovelace and Babbage: The (Mostly) True Story of the First Computer*. Particular Books, April 2015.  ISBN: 978-0-141-98151-2
+    Lovelace and Babbage: The (Mostly) True Story of the First Computer*. Particular Books, April 2015. ISBN: 978-0-141-98151-2
 
 1.  Coda Hale:
     “[You Can’t Sacrifice Partition Tolerance](http://codahale.com/you-cant-sacrifice-partition-tolerance/),” *codahale.com*, October 7, 2010.
@@ -91,7 +91,7 @@ Chapter 8 References
     “[The Ultimate SO_LINGER Page, or: Why Is My TCP Not Reliable](http://blog.netherlabs.nl/articles/2009/01/18/the-ultimate-so_linger-page-or-why-is-my-tcp-not-reliable),” *blog.netherlabs.nl*, January 18, 2009.
 
 1.  Nicolas Liochon:
-    “[CAP:   If All You Have Is a Timeout, Everything Looks Like a Partition](http://blog.thislongrun.com/2015/05/CAP-theorem-partition-timeout-zookeeper.html),” *blog.thislongrun.com*,
+    “[CAP: If All You Have Is a Timeout, Everything Looks Like a Partition](http://blog.thislongrun.com/2015/05/CAP-theorem-partition-timeout-zookeeper.html),” *blog.thislongrun.com*,
     May 25, 2015.
 
 1.  Jerome H. Saltzer, David P. Reed, and David D. Clark:
@@ -182,7 +182,7 @@ Chapter 8 References
     “[Leap Second Crashes Half the Internet](http://www.somebits.com/weblog/tech/bad/leap-second-2012.html),” *somebits.com*, July 3, 2012.
 
 1.  Christopher Pascoe:
-    “[Time,   Technology and Leaping Seconds](http://googleblog.blogspot.co.uk/2011/09/time-technology-and-leaping-seconds.html),” *googleblog.blogspot.co.uk*, September 15, 2011.
+    “[Time, Technology and Leaping Seconds](http://googleblog.blogspot.co.uk/2011/09/time-technology-and-leaping-seconds.html),” *googleblog.blogspot.co.uk*, September 15, 2011.
 
 1.  Mingxue Zhao and Jeff Barr:
     “[Look Before You Leap – The Coming Leap Second and AWS](https://aws.amazon.com/blogs/aws/look-before-you-leap-the-coming-leap-second-and-aws/),” *aws.amazon.com*, May 18, 2015.

--- a/chapter-09-refs.md
+++ b/chapter-09-refs.md
@@ -373,8 +373,7 @@ Chapter 9 References
 1.  Paul Randal:
     “[Real World Story of DBCC PAGE Saving the Day](http://www.sqlskills.com/blogs/paul/real-world-story-of-dbcc-page-saving-the-day/),” *sqlskills.com*, June 19, 2013.
 
-1.  “[in-doubt xact resolution Server Configuration Option](https://msdn.microsoft.com/en-us/library/ms179586.aspx),” SQL Server 2016 documentation, Microsoft, Inc.,
-    2016.
+1.  “[in-doubt xact resolution Server Configuration Option](https://msdn.microsoft.com/en-us/library/ms179586.aspx),” SQL Server 2016 documentation, Microsoft, Inc., 2016.
 
 1.  Cynthia Dwork, Nancy Lynch, and Larry Stockmeyer:
     “[Consensus in the Presence of Partial Synchrony](https://web.archive.org/web/20210318133551/https://www.net.t-labs.tu-berlin.de/~petr/ADC-07/papers/DLS88.pdf),” *Journal of the ACM*, volume 35, number 2, pages 288–323,

--- a/chapter-09-refs.md
+++ b/chapter-09-refs.md
@@ -45,7 +45,7 @@ Chapter 9 References
     “[Computational Techniques in Knossos](https://aphyr.com/posts/314-computational-techniques-in-knossos),” *aphyr.com*, May 17, 2014.
 
 1.  Peter Bailis:
-      “[Linearizability   Versus Serializability](http://www.bailis.org/blog/linearizability-versus-serializability/),” *bailis.org*, September 24, 2014.
+      “[Linearizability Versus Serializability](http://www.bailis.org/blog/linearizability-versus-serializability/),” *bailis.org*, September 24, 2014.
 
 1.  Philip A. Bernstein, Vassos Hadzilacos, and Nathan Goodman:
     [*Concurrency Control and Recovery in Database Systems*](https://www.microsoft.com/en-us/research/people/philbe/book/).
@@ -192,7 +192,7 @@ Chapter 9 References
     [doi:10.1145/176575.176576](http://dx.doi.org/10.1145/176575.176576)
 
 1.  Mustaque Ahamad, Gil Neiger, James E. Burns, et al.:
-      “[Causal   Memory: Definitions, Implementation, and Programming](http://www-i2.informatik.rwth-aachen.de/i2/fileadmin/user_upload/documents/Seminar_MCMM11/Causal_memory_1996.pdf),” *Distributed
+      “[Causal Memory: Definitions, Implementation, and Programming](http://www-i2.informatik.rwth-aachen.de/i2/fileadmin/user_upload/documents/Seminar_MCMM11/Causal_memory_1996.pdf),” *Distributed
       Computing*, volume 9, number 1, pages 37–49, March 1995.
       [doi:10.1007/BF01784241](http://dx.doi.org/10.1007/BF01784241)
 

--- a/chapter-09-refs.md
+++ b/chapter-09-refs.md
@@ -454,4 +454,3 @@ Chapter 9 References
     “[A History of the Virtual Synchrony Replication Model](https://ptolemy.berkeley.edu/projects/truststc/pubs/713/History%20of%20the%20Virtual%20Synchrony%20Replication%20Model%202010.pdf),”
     in *Replication: Theory and Practice*, Springer LNCS volume 5959, chapter 6, pages 91–120, 2010.
     ISBN: 978-3-642-11293-5, [doi:10.1007/978-3-642-11294-2_6](http://dx.doi.org/10.1007/978-3-642-11294-2_6)
-

--- a/chapter-09-refs.md
+++ b/chapter-09-refs.md
@@ -45,7 +45,7 @@ Chapter 9 References
     “[Computational Techniques in Knossos](https://aphyr.com/posts/314-computational-techniques-in-knossos),” *aphyr.com*, May 17, 2014.
 
 1.  Peter Bailis:
-      “[Linearizability Versus Serializability](http://www.bailis.org/blog/linearizability-versus-serializability/),” *bailis.org*, September 24, 2014.
+    “[Linearizability Versus Serializability](http://www.bailis.org/blog/linearizability-versus-serializability/),” *bailis.org*, September 24, 2014.
 
 1.  Philip A. Bernstein, Vassos Hadzilacos, and Nathan Goodman:
     [*Concurrency Control and Recovery in Database Systems*](https://www.microsoft.com/en-us/research/people/philbe/book/).
@@ -75,13 +75,13 @@ Chapter 9 References
     “[Call Me Maybe: etcd and Consul](https://aphyr.com/posts/316-call-me-maybe-etcd-and-consul),” *aphyr.com*, June 9, 2014.
 
 1.  Flavio P. Junqueira, Benjamin C. Reed, and Marco Serafini:
-      “[Zab: High-Performance Broadcast for Primary-Backup Systems](https://web.archive.org/web/20220419064903/https://marcoserafini.github.io/papers/zab.pdf),”
-      at *41st IEEE International Conference on Dependable Systems and Networks* (DSN), June 2011.
-      [doi:10.1109/DSN.2011.5958223](http://dx.doi.org/10.1109/DSN.2011.5958223)
+    “[Zab: High-Performance Broadcast for Primary-Backup Systems](https://web.archive.org/web/20220419064903/https://marcoserafini.github.io/papers/zab.pdf),”
+    at *41st IEEE International Conference on Dependable Systems and Networks* (DSN), June 2011.
+    [doi:10.1109/DSN.2011.5958223](http://dx.doi.org/10.1109/DSN.2011.5958223)
 
 1.  Diego Ongaro and John K. Ousterhout:
-      “[In Search of an Understandable Consensus Algorithm](https://www.usenix.org/system/files/conference/atc14/atc14-paper-ongaro.pdf),”
-      at *USENIX Annual Technical Conference* (ATC), June 2014.
+    “[In Search of an Understandable Consensus Algorithm](https://www.usenix.org/system/files/conference/atc14/atc14-paper-ongaro.pdf),”
+    at *USENIX Annual Technical Conference* (ATC), June 2014.
 
 1.  Hagit Attiya, Amotz Bar-Noy, and Danny Dolev:
     “[Sharing Memory Robustly in Message-Passing Systems](http://www.cse.huji.ac.il/course/2004/dist/p124-attiya.pdf),”
@@ -192,9 +192,9 @@ Chapter 9 References
     [doi:10.1145/176575.176576](http://dx.doi.org/10.1145/176575.176576)
 
 1.  Mustaque Ahamad, Gil Neiger, James E. Burns, et al.:
-      “[Causal Memory: Definitions, Implementation, and Programming](http://www-i2.informatik.rwth-aachen.de/i2/fileadmin/user_upload/documents/Seminar_MCMM11/Causal_memory_1996.pdf),” *Distributed
-      Computing*, volume 9, number 1, pages 37–49, March 1995.
-      [doi:10.1007/BF01784241](http://dx.doi.org/10.1007/BF01784241)
+    “[Causal Memory: Definitions, Implementation, and Programming](http://www-i2.informatik.rwth-aachen.de/i2/fileadmin/user_upload/documents/Seminar_MCMM11/Causal_memory_1996.pdf),” *Distributed
+    Computing*, volume 9, number 1, pages 37–49, March 1995.
+    [doi:10.1007/BF01784241](http://dx.doi.org/10.1007/BF01784241)
 
 1.  Wyatt Lloyd, Michael J. Freedman,
     Michael Kaminsky, and David G. Andersen:
@@ -223,7 +223,7 @@ Chapter 9 References
     [doi:10.1007/978-3-319-19129-4_6](http://dx.doi.org/10.1007/978-3-319-19129-4_6)
 
 1.  Rob Conery:
-      “[A Better ID Generator for PostgreSQL](https://web.archive.org/web/20220118044729/http://rob.conery.io/2014/05/29/a-better-id-generator-for-postgresql/),” *rob.conery.io*, May 29, 2014.
+    “[A Better ID Generator for PostgreSQL](https://web.archive.org/web/20220118044729/http://rob.conery.io/2014/05/29/a-better-id-generator-for-postgresql/),” *rob.conery.io*, May 29, 2014.
 
 1.  Leslie Lamport:
     “[Time, Clocks, and the Ordering of Events in a Distributed System](https://www.microsoft.com/en-us/research/publication/time-clocks-ordering-events-distributed-system/),”

--- a/chapter-09-refs.md
+++ b/chapter-09-refs.md
@@ -67,7 +67,7 @@ Chapter 9 References
     *Oracle 10g RAC Grid, Services & Clustering*. Elsevier Digital Press, 2006.
     ISBN: 978-1-555-58321-7
 
-1.  Peter Bailis, Alan Fekete, Michael J Franklin, et al.:
+1.  Peter Bailis, Alan Fekete, Michael J. Franklin, et al.:
     “[Coordination-Avoiding Database Systems](http://arxiv.org/pdf/1402.2237.pdf),”
     *Proceedings of the VLDB Endowment*, volume 8, number 3, pages 185–196, November 2014.
 
@@ -204,7 +204,7 @@ Chapter 9 References
 1.  Marek Zawirski, Annette Bieniusa, Valter Balegas, et al.:
     “[SwiftCloud: Fault-Tolerant Geo-Replication Integrated All the Way to the Client Machine](http://arxiv.org/abs/1310.3107),” INRIA Research Report 8347, August 2013.
 
-1.  Peter Bailis, Ali Ghodsi, Joseph M Hellerstein, and Ion Stoica:
+1.  Peter Bailis, Ali Ghodsi, Joseph M. Hellerstein, and Ion Stoica:
     “[Bolt-on Causal Consistency](http://db.cs.berkeley.edu/papers/sigmod13-bolton.pdf),” at
     *ACM International Conference on Management of Data* (SIGMOD), June 2013.
 
@@ -269,7 +269,7 @@ Chapter 9 References
     “[Apache HBase High Availability at the Next Level](https://web.archive.org/web/20160405122821/http://hortonworks.com/blog/apache-hbase-high-availability-next-level/),”
     *hortonworks.com*, January 22, 2015.
 
-1.  Brian F Cooper, Raghu Ramakrishnan, Utkarsh Srivastava, et al.:
+1.  Brian F. Cooper, Raghu Ramakrishnan, Utkarsh Srivastava, et al.:
     “[PNUTS: Yahoo!’s Hosted Data Serving Platform](http://www.mpi-sws.org/~druschel/courses/ds/papers/cooper-pnuts.pdf),” at *34th International Conference on Very Large Data
     Bases* (VLDB), August 2008.
     [doi:10.14778/1454159.1454167](http://dx.doi.org/10.14778/1454159.1454167)

--- a/chapter-09-refs.md
+++ b/chapter-09-refs.md
@@ -208,8 +208,7 @@ Chapter 9 References
     “[Bolt-on Causal Consistency](http://db.cs.berkeley.edu/papers/sigmod13-bolton.pdf),” at
     *ACM International Conference on Management of Data* (SIGMOD), June 2013.
 
-1.  Philippe Ajoux, Nathan Bronson, Sanjeev
-    Kumar, et al.:
+1.  Philippe Ajoux, Nathan Bronson, Sanjeev Kumar, et al.:
     “[Challenges to Adopting Stronger Consistency at Scale](https://www.usenix.org/system/files/conference/hotos15/hotos15-paper-ajoux.pdf),” at *15th USENIX Workshop on Hot Topics in
     Operating Systems* (HotOS), May 2015.
 
@@ -240,8 +239,7 @@ Chapter 9 References
     John Wiley & Sons, 2004. ISBN: 978-0-471-45324-6,
     [doi:10.1002/0471478210](http://dx.doi.org/10.1002/0471478210)
 
-1.  Mahesh
-    Balakrishnan, Dahlia Malkhi, Vijayan Prabhakaran, et al.:
+1.  Mahesh Balakrishnan, Dahlia Malkhi, Vijayan Prabhakaran, et al.:
     “[CORFU: A Shared Log Design for Flash Clusters](https://www.usenix.org/system/files/conference/nsdi12/nsdi12-final30.pdf),” at *9th USENIX Symposium on Networked
     Systems Design and Implementation* (NSDI), April 2012.
 
@@ -285,9 +283,9 @@ Chapter 9 References
     “[Impossibility of Distributed Consensus with One Faulty Process](https://groups.csail.mit.edu/tds/papers/Lynch/jacm85.pdf),” *Journal of the ACM*, volume 32, number 2, pages 374–382, April 1985.
     [doi:10.1145/3149.214121](http://dx.doi.org/10.1145/3149.214121)
 
-1.  Michael Ben-Or: “Another Advantage of Free
-    Choice: Completely Asynchronous Agreement Protocols,” at *2nd ACM Symposium on Principles of
-    Distributed Computing* (PODC), August 1983.
+1.  Michael Ben-Or:
+    “Another Advantage of Free Choice: Completely Asynchronous Agreement Protocols,”
+    at *2nd ACM Symposium on Principles of Distributed Computing* (PODC), August 1983.
     [doi:10.1145/800221.806707](http://dl.acm.org/citation.cfm?id=806707)
 
 1.  Jim N. Gray and Leslie Lamport:
@@ -300,8 +298,8 @@ Chapter 9 References
     at *9th International Workshop on Distributed Algorithms* (WDAG), September 1995.
     [doi:10.1007/BFb0022140](http://dx.doi.org/10.1007/BFb0022140)
 
-1.  Thanumalayan Sankaranarayana Pillai, Vijay Chidambaram,
-    Ramnatthan Alagappan, et al.: “[All File Systems Are Not Created Equal: On the Complexity of Crafting Crash-Consistent Applications](http://research.cs.wisc.edu/wind/Publications/alice-osdi14.pdf),”
+1.  Thanumalayan Sankaranarayana Pillai, Vijay Chidambaram, Ramnatthan Alagappan, et al.:
+    “[All File Systems Are Not Created Equal: On the Complexity of Crafting Crash-Consistent Applications](http://research.cs.wisc.edu/wind/Publications/alice-osdi14.pdf),”
     at *11th USENIX Symposium on Operating Systems Design and Implementation* (OSDI),
     October 2014.
 
@@ -425,8 +423,8 @@ Chapter 9 References
     volume 12, number 4, pages 472–484, September 2014.
     [doi:10.1109/TDSC.2014.2355848](http://dx.doi.org/10.1109/TDSC.2014.2355848)
 
-1.  Will
-    Portnoy: “[Lessons Learned from Implementing Paxos](http://blog.willportnoy.com/2012/06/lessons-learned-from-paxos.html),” *blog.willportnoy.com*, June 14, 2012.
+1.  Will Portnoy:
+    “[Lessons Learned from Implementing Paxos](http://blog.willportnoy.com/2012/06/lessons-learned-from-paxos.html),” *blog.willportnoy.com*, June 14, 2012.
 
 1.  Heidi Howard, Dahlia Malkhi, and Alexander Spiegelman:
     “[Flexible Paxos: Quorum Intersection Revisited](https://drops.dagstuhl.de/opus/volltexte/2017/7094/pdf/LIPIcs-OPODIS-2016-25.pdf),”

--- a/chapter-10-refs.md
+++ b/chapter-10-refs.md
@@ -289,8 +289,7 @@ Chapter 10 References
     Design and Implementation* (OSDI), October 2012.
 
 1.  Andrew Lenharth, Donald Nguyen, and Keshav Pingali:
-    “[Parallel Graph Analytics](http://cacm.acm.org/magazines/2016/5/201591-parallel-graph-analytics/fulltext),” *Communications of the ACM*, volume 59, number 5, pages 78–87, May
-    2016. [doi:10.1145/2901919](http://dx.doi.org/10.1145/2901919)
+    “[Parallel Graph Analytics](http://cacm.acm.org/magazines/2016/5/201591-parallel-graph-analytics/fulltext),” *Communications of the ACM*, volume 59, number 5, pages 78–87, May 2016. [doi:10.1145/2901919](http://dx.doi.org/10.1145/2901919)
 
 1.  Fabian Hüske:
     “[Peeking into Apache Flink's Engine Room](http://flink.apache.org/news/2015/03/13/peeking-into-Apache-Flinks-Engine-Room.html),” *flink.apache.org*, March 13, 2015.

--- a/chapter-10-refs.md
+++ b/chapter-10-refs.md
@@ -185,10 +185,10 @@ Chapter 10 References
     *blog.cloudera.com*, September 27, 2013.
 
 1.  Nathan Marz:
-      “[How to Beat the CAP Theorem](http://nathanmarz.com/blog/how-to-beat-the-cap-theorem.html),” *nathanmarz.com*, October 13, 2011.
+    “[How to Beat the CAP Theorem](http://nathanmarz.com/blog/how-to-beat-the-cap-theorem.html),” *nathanmarz.com*, October 13, 2011.
 
 1.  Molly Bartlett Dishman and Martin Fowler:
-      “[Agile Architecture](https://web.archive.org/web/20161130034721/http://conferences.oreilly.com/software-architecture/sa2015/public/schedule/detail/40388),” at *O'Reilly Software Architecture Conference*, March 2015.
+    “[Agile Architecture](https://web.archive.org/web/20161130034721/http://conferences.oreilly.com/software-architecture/sa2015/public/schedule/detail/40388),” at *O'Reilly Software Architecture Conference*, March 2015.
 
 1.  David J. DeWitt and Jim N. Gray:
     “[Parallel Database Systems: The Future of High Performance Database Systems](http://www.cs.cmu.edu/~pavlo/courses/fall2013/static/papers/dewittgray92.pdf),”

--- a/chapter-10-refs.md
+++ b/chapter-10-refs.md
@@ -297,7 +297,7 @@ Chapter 10 References
     “[Hive 0.14 Cost Based Optimizer (CBO) Technical Overview](https://web.archive.org/web/20170607112708/http://hortonworks.com/blog/hive-0-14-cost-based-optimizer-cbo-technical-overview/),”
     *hortonworks.com*, March 2, 2015.
 
-1.  Michael Armbrust, Reynold S Xin, Cheng Lian, et al.:
+1.  Michael Armbrust, Reynold S. Xin, Cheng Lian, et al.:
     “[Spark SQL: Relational Data Processing in Spark](http://people.csail.mit.edu/matei/papers/2015/sigmod_spark_sql.pdf),” at *ACM International Conference on Management of Data* (SIGMOD), June 2015.
     [doi:10.1145/2723372.2742797](http://dx.doi.org/10.1145/2723372.2742797)
 

--- a/chapter-10-refs.md
+++ b/chapter-10-refs.md
@@ -66,8 +66,7 @@ Chapter 10 References
     “[Two File Descriptors for Sockets](http://cr.yp.to/tcpip/twofd.html),” *cr.yp.to*.
 
 1.  Rob Pike and Dennis M. Ritchie:
-    “[The Styx Architecture for Distributed Systems](http://doc.cat-v.org/inferno/4th_edition/styx),” *Bell Labs Technical Journal*, volume 4, number 2, pages
-146–152, April 1999.
+    “[The Styx Architecture for Distributed Systems](http://doc.cat-v.org/inferno/4th_edition/styx),” *Bell Labs Technical Journal*, volume 4, number 2, pages 146–152, April 1999.
 
 1.  Sanjay Ghemawat, Howard Gobioff, and Shun-Tak
     Leung: “[The Google File System](http://research.google.com/archive/gfs-sosp2003.pdf),”

--- a/chapter-10-refs.md
+++ b/chapter-10-refs.md
@@ -146,8 +146,7 @@ Chapter 10 References
     Apache Pig Documentation, *pig.apache.org*, 2017.
 
 1.  Sriranjan Manjunath:
-    “[Skewed Join](https://web.archive.org/web/20151228114742/https://wiki.apache.org/pig/PigSkewedJoinSpec),” *wiki.apache.org*,
-    2009.
+    “[Skewed Join](https://web.archive.org/web/20151228114742/https://wiki.apache.org/pig/PigSkewedJoinSpec),” *wiki.apache.org*, 2009.
 
 1.  David J. DeWitt, Jeffrey F. Naughton, Donovan A.
     Schneider, and S. Seshadri: “[Practical Skew Handling in Parallel Joins](http://www.vldb.org/conf/1992/P027.PDF),” at *18th International Conference on Very Large Data Bases* (VLDB), August 1992.

--- a/chapter-10-refs.md
+++ b/chapter-10-refs.md
@@ -185,7 +185,7 @@ Chapter 10 References
     *blog.cloudera.com*, September 27, 2013.
 
 1.  Nathan Marz:
-      “[How to Beat the CAP   Theorem](http://nathanmarz.com/blog/how-to-beat-the-cap-theorem.html),” *nathanmarz.com*, October 13, 2011.
+      “[How to Beat the CAP Theorem](http://nathanmarz.com/blog/how-to-beat-the-cap-theorem.html),” *nathanmarz.com*, October 13, 2011.
 
 1.  Molly Bartlett Dishman and Martin Fowler:
       “[Agile Architecture](https://web.archive.org/web/20161130034721/http://conferences.oreilly.com/software-architecture/sa2015/public/schedule/detail/40388),” at *O'Reilly Software Architecture Conference*, March 2015.

--- a/chapter-11-refs.md
+++ b/chapter-11-refs.md
@@ -219,8 +219,7 @@ Chapter 11 References
 1.  “[Fossil Documentation: Deleting Content from Fossil](http://fossil-scm.org/index.html/doc/trunk/www/shunning.wiki),” *fossil-scm.org*, 2016.
 
 1.  Jay Kreps:
-    “[The irony of distributed systems is that data loss is really easy but deleting data is surprisingly hard,](https://twitter.com/jaykreps/status/582580836425330688)” *twitter.com*, March 30,
-    2015.
+    “[The irony of distributed systems is that data loss is really easy but deleting data is surprisingly hard,](https://twitter.com/jaykreps/status/582580836425330688)” *twitter.com*, March 30, 2015.
 
 1.  David C. Luckham:
     “[What’s the Difference Between ESP and CEP?](http://www.complexevents.com/2006/08/01/what%E2%80%99s-the-difference-between-esp-and-cep/),” *complexevents.com*, August 1, 2006.
@@ -263,8 +262,7 @@ Chapter 11 References
     “[Why Local State Is a Fundamental Primitive in Stream Processing](https://www.oreilly.com/ideas/why-local-state-is-a-fundamental-primitive-in-stream-processing),” *oreilly.com*, July 31, 2014.
 
 1.  Shay Banon:
-    “[Percolator](https://www.elastic.co/blog/percolator),” *elastic.co*, February 8,
-    2011.
+    “[Percolator](https://www.elastic.co/blog/percolator),” *elastic.co*, February 8, 2011.
 
 1.  Alan Woodward and Martin Kleppmann:
     “[Real-Time Full-Text Search with Luwak and Samza](http://martin.kleppmann.com/2015/04/13/real-time-full-text-search-luwak-samza.html),” *martin.kleppmann.com*, April 13, 2015.

--- a/chapter-11-refs.md
+++ b/chapter-11-refs.md
@@ -35,14 +35,14 @@ Chapter 11 References
     “[Brubeck, a statsd-Compatible Metrics Aggregator](http://githubengineering.com/brubeck/),” *githubengineering.com*, June 15, 2015.
 
 1.  Seth Lowenberger:
-      “[MoldUDP64   Protocol Specification V 1.00](http://www.nasdaqtrader.com/content/technicalsupport/specifications/dataproducts/moldudp64.pdf),” *nasdaqtrader.com*, July 2009.
+      “[MoldUDP64 Protocol Specification V 1.00](http://www.nasdaqtrader.com/content/technicalsupport/specifications/dataproducts/moldudp64.pdf),” *nasdaqtrader.com*, July 2009.
 
 1.  Pieter Hintjens:
       [*ZeroMQ – The Guide*](http://zguide.zeromq.org/page:all). O'Reilly Media, 2013.
       ISBN: 978-1-449-33404-8
 
 1.  Ian Malpass:
-      “[Measure   Anything, Measure Everything](https://codeascraft.com/2011/02/15/measure-anything-measure-everything/),” *codeascraft.com*, February 15, 2011.
+      “[Measure Anything, Measure Everything](https://codeascraft.com/2011/02/15/measure-anything-measure-everything/),” *codeascraft.com*, February 15, 2011.
 
 1.  Dieter Plaetinck:
       “[25 Graphite, Grafana and statsd Gotchas](https://grafana.com/blog/2016/03/03/25-graphite-grafana-and-statsd-gotchas/),”

--- a/chapter-11-refs.md
+++ b/chapter-11-refs.md
@@ -350,4 +350,3 @@ Chapter 11 References
 
 1.  Adam Warski:
     “[Kafka Streams – How Does It Fit the Stream Processing Landscape?](https://softwaremill.com/kafka-streams-how-does-it-fit-stream-landscape/),” *softwaremill.com*, June 1, 2016.
-

--- a/chapter-11-refs.md
+++ b/chapter-11-refs.md
@@ -247,8 +247,7 @@ Chapter 11 References
     High-Performance Big Data Computing* (HPBDC), May 2016.
     [doi:10.1109/IPDPSW.2016.141](http://dx.doi.org/10.1109/IPDPSW.2016.141)
 
-1.  Philippe Flajolet, Éric Fusy, Olivier
-    Gandouet, and Frédéric Meunier:
+1.  Philippe Flajolet, Éric Fusy, Olivier Gandouet, and Frédéric Meunier:
     “[HyperLogLog: The Analysis of a Near-Optimal Cardinality Estimation Algorithm](http://algo.inria.fr/flajolet/Publications/FlFuGaMe07.pdf),”
     at *Conference on Analysis of Algorithms* (AofA), June 2007.
 
@@ -287,8 +286,7 @@ Chapter 11 References
 
 1.  “[State Management](http://samza.apache.org/learn/documentation/0.10/container/state-management.html),” Apache Samza 0.10 Documentation, *samza.apache.org*, December 2015.
 
-1.  Rajagopal Ananthanarayanan,
-    Venkatesh Basker, Sumit Das, et al.:
+1.  Rajagopal Ananthanarayanan, Venkatesh Basker, Sumit Das, et al.:
     “[Photon: Fault-Tolerant and Scalable Joining of Continuous Data Streams](http://research.google.com/pubs/pub41318.html),” at *ACM International Conference on Management of
     Data* (SIGMOD), June 2013.
     [doi:10.1145/2463676.2465272](http://dx.doi.org/10.1145/2463676.2465272)
@@ -339,10 +337,9 @@ Chapter 11 References
     “[Re: Trying to Achieve Deterministic Behavior on Recovery/Rewind](http://mail-archives.apache.org/mod_mbox/samza-dev/201409.mbox/%3CCAOeJiJg%2Bc7Ei%3DgzCuOz30DD3G5Hm9yFY%3DUJ6SafdNUFbvRgorg%40mail.gmail.com%3E),” email to *samza-dev* mailing list,
     September 9, 2014.
 
-1.  E. N. (Mootaz) Elnozahy,
-    Lorenzo Alvisi, Yi-Min Wang, and David B. Johnson:
-    “[A Survey of Rollback-Recovery Protocols in Message-Passing Systems](http://www.cs.utexas.edu/~lorenzo/papers/SurveyFinal.pdf),” *ACM Computing Surveys*, volume 34, number 3,
-    pages 375–408, September 2002.
+1.  E. N. (Mootaz) Elnozahy, Lorenzo Alvisi, Yi-Min Wang, and David B. Johnson:
+    “[A Survey of Rollback-Recovery Protocols in Message-Passing Systems](http://www.cs.utexas.edu/~lorenzo/papers/SurveyFinal.pdf),”
+    *ACM Computing Surveys*, volume 34, number 3, pages 375–408, September 2002.
     [doi:10.1145/568522.568525](http://dx.doi.org/10.1145/568522.568525)
 
 1.  Adam Warski:

--- a/chapter-11-refs.md
+++ b/chapter-11-refs.md
@@ -301,8 +301,7 @@ Chapter 11 References
     “[Doing the Impossible: Exactly-Once Messaging Patterns in Kafka](http://ben.kirw.in/2014/11/28/kafka-patterns/),” *ben.kirw.in*, November 28, 2014.
 
 1.  Pat Helland:
-    “[Data on the Outside Versus Data on the Inside](http://cidrdb.org/cidr2005/papers/P12.pdf),” at *2nd Biennial Conference on Innovative Data Systems Research* (CIDR), January
-    2005.
+    “[Data on the Outside Versus Data on the Inside](http://cidrdb.org/cidr2005/papers/P12.pdf),” at *2nd Biennial Conference on Innovative Data Systems Research* (CIDR), January 2005.
 
 1.  Ralph Kimball and Margy Ross:
     *The Data Warehouse Toolkit: The Definitive Guide to Dimensional Modeling*,

--- a/chapter-11-refs.md
+++ b/chapter-11-refs.md
@@ -35,21 +35,21 @@ Chapter 11 References
     “[Brubeck, a statsd-Compatible Metrics Aggregator](http://githubengineering.com/brubeck/),” *githubengineering.com*, June 15, 2015.
 
 1.  Seth Lowenberger:
-      “[MoldUDP64 Protocol Specification V 1.00](http://www.nasdaqtrader.com/content/technicalsupport/specifications/dataproducts/moldudp64.pdf),” *nasdaqtrader.com*, July 2009.
+    “[MoldUDP64 Protocol Specification V 1.00](http://www.nasdaqtrader.com/content/technicalsupport/specifications/dataproducts/moldudp64.pdf),” *nasdaqtrader.com*, July 2009.
 
 1.  Pieter Hintjens:
-      [*ZeroMQ – The Guide*](http://zguide.zeromq.org/page:all). O'Reilly Media, 2013.
-      ISBN: 978-1-449-33404-8
+    [*ZeroMQ – The Guide*](http://zguide.zeromq.org/page:all). O'Reilly Media, 2013.
+    ISBN: 978-1-449-33404-8
 
 1.  Ian Malpass:
-      “[Measure Anything, Measure Everything](https://codeascraft.com/2011/02/15/measure-anything-measure-everything/),” *codeascraft.com*, February 15, 2011.
+    “[Measure Anything, Measure Everything](https://codeascraft.com/2011/02/15/measure-anything-measure-everything/),” *codeascraft.com*, February 15, 2011.
 
 1.  Dieter Plaetinck:
-      “[25 Graphite, Grafana and statsd Gotchas](https://grafana.com/blog/2016/03/03/25-graphite-grafana-and-statsd-gotchas/),”
-      *grafana.com*, March 3, 2016.
+    “[25 Graphite, Grafana and statsd Gotchas](https://grafana.com/blog/2016/03/03/25-graphite-grafana-and-statsd-gotchas/),”
+    *grafana.com*, March 3, 2016.
 
 1.  Jeff Lindsay:
-      “[Web Hooks to Revolutionize the Web](https://web.archive.org/web/20180928201955/http://progrium.com/blog/2007/05/03/web-hooks-to-revolutionize-the-web/),” *progrium.com*, May 3, 2007.
+    “[Web Hooks to Revolutionize the Web](https://web.archive.org/web/20180928201955/http://progrium.com/blog/2007/05/03/web-hooks-to-revolutionize-the-web/),” *progrium.com*, May 3, 2007.
 
 1.  Jim N. Gray:
     “[Queues Are Databases](https://arxiv.org/pdf/cs/0701158.pdf),”

--- a/chapter-12-refs.md
+++ b/chapter-12-refs.md
@@ -303,8 +303,7 @@ Chapter 12 References
     “[Software development is starting to involve important ethical choices](https://twitter.com/fchollet/status/792958695722201088),” *twitter.com*, October 30, 2016.
 
 1.  Igor Perisic:
-    “[Making Hard Choices: The Quest for Ethics in Machine Learning](https://engineering.linkedin.com/blog/2016/11/making-hard-choices--the-quest-for-ethics-in-machine-learning),” *engineering.linkedin.com*, November
-    2016.
+    “[Making Hard Choices: The Quest for Ethics in Machine Learning](https://engineering.linkedin.com/blog/2016/11/making-hard-choices--the-quest-for-ethics-in-machine-learning),” *engineering.linkedin.com*, November 2016.
 
 1.  John Naughton:
     “[Algorithm Writers Need a Code of Conduct](https://www.theguardian.com/commentisfree/2015/dec/06/algorithm-writers-should-have-code-of-conduct),” *theguardian.com*, December 6, 2015.

--- a/chapter-12-refs.md
+++ b/chapter-12-refs.md
@@ -16,7 +16,7 @@ Chapter 12 References
     *4th Biennial Conference on Innovative Data Systems Research* (CIDR), January 2009.
 
 1.  Jessica Kerr:
-      “[Provenance   and Causality in Distributed Systems](https://web.archive.org/web/20190425150540/http://blog.jessitron.com/2016/09/provenance-and-causality-in-distributed.html),”
+      “[Provenance and Causality in Distributed Systems](https://web.archive.org/web/20190425150540/http://blog.jessitron.com/2016/09/provenance-and-causality-in-distributed.html),”
       *blog.jessitron.com*, September 25, 2016.
 
 1.  Kostas Tzoumas:
@@ -49,11 +49,11 @@ Chapter 12 References
     Manning, 2015. ISBN: 978-1-617-29034-3
 
 1.  Oscar Boykin, Sam Ritchie, Ian O'Connell, and
-      Jimmy Lin: “[Summingbird: A Framework for   Integrating Batch and Online MapReduce Computations](http://www.vldb.org/pvldb/vol7/p1441-boykin.pdf),” at *40th International Conference on
+      Jimmy Lin: “[Summingbird: A Framework for Integrating Batch and Online MapReduce Computations](http://www.vldb.org/pvldb/vol7/p1441-boykin.pdf),” at *40th International Conference on
       Very Large Data Bases* (VLDB), September 2014.
 
 1.  Jay Kreps:
-      “[Questioning the   Lambda Architecture](https://www.oreilly.com/ideas/questioning-the-lambda-architecture),” *oreilly.com*, July 2, 2014.
+      “[Questioning the Lambda Architecture](https://www.oreilly.com/ideas/questioning-the-lambda-architecture),” *oreilly.com*, July 2, 2014.
 
 1.  Raul Castro Fernandez, Peter Pietzuch, Jay Kreps, et al.:
     “[Liquid: Unifying Nearline and Offline Big Data Integration](http://cidrdb.org/cidr2015/Papers/CIDR15_Paper25u.pdf),”
@@ -74,14 +74,14 @@ Chapter 12 References
 
 1.  Jennie Duggan,
       Aaron J. Elmore, Michael Stonebraker, et al.:
-      “[The BigDAWG Polystore   System](https://dspace.mit.edu/handle/1721.1/100936),” *ACM SIGMOD Record*, volume 44, number 2, pages 11–16, June 2015.
+      “[The BigDAWG Polystore System](https://dspace.mit.edu/handle/1721.1/100936),” *ACM SIGMOD Record*, volume 44, number 2, pages 11–16, June 2015.
       [doi:10.1145/2814710.2814713](http://dx.doi.org/10.1145/2814710.2814713)
 
 1.  Patrycja Dybka:
-      “[Foreign   Data Wrappers for PostgreSQL](http://www.vertabelo.com/blog/technical-articles/foreign-data-wrappers-for-postgresql),” *vertabelo.com*, March 24, 2015.
+      “[Foreign Data Wrappers for PostgreSQL](http://www.vertabelo.com/blog/technical-articles/foreign-data-wrappers-for-postgresql),” *vertabelo.com*, March 24, 2015.
 
 1.  David B. Lomet, Alan Fekete, Gerhard Weikum, and Mike Zwilling:
-      “[Unbundling   Transaction Services in the Cloud](https://www.microsoft.com/en-us/research/publication/unbundling-transaction-services-in-the-cloud/),” at *4th Biennial Conference on Innovative Data Systems
+      “[Unbundling Transaction Services in the Cloud](https://www.microsoft.com/en-us/research/publication/unbundling-transaction-services-in-the-cloud/),” at *4th Biennial Conference on Innovative Data Systems
       Research* (CIDR), January 2009.
 
 1.  Martin Kleppmann and Jay Kreps:

--- a/chapter-12-refs.md
+++ b/chapter-12-refs.md
@@ -16,8 +16,8 @@ Chapter 12 References
     *4th Biennial Conference on Innovative Data Systems Research* (CIDR), January 2009.
 
 1.  Jessica Kerr:
-      “[Provenance and Causality in Distributed Systems](https://web.archive.org/web/20190425150540/http://blog.jessitron.com/2016/09/provenance-and-causality-in-distributed.html),”
-      *blog.jessitron.com*, September 25, 2016.
+    “[Provenance and Causality in Distributed Systems](https://web.archive.org/web/20190425150540/http://blog.jessitron.com/2016/09/provenance-and-causality-in-distributed.html),”
+    *blog.jessitron.com*, September 25, 2016.
 
 1.  Kostas Tzoumas:
     “[Batch Is a Special Case of Streaming](http://data-artisans.com/blog/batch-is-a-special-case-of-streaming/),” *data-artisans.com*, September 15, 2015.
@@ -49,11 +49,11 @@ Chapter 12 References
     Manning, 2015. ISBN: 978-1-617-29034-3
 
 1.  Oscar Boykin, Sam Ritchie, Ian O'Connell, and
-      Jimmy Lin: “[Summingbird: A Framework for Integrating Batch and Online MapReduce Computations](http://www.vldb.org/pvldb/vol7/p1441-boykin.pdf),” at *40th International Conference on
-      Very Large Data Bases* (VLDB), September 2014.
+    Jimmy Lin: “[Summingbird: A Framework for Integrating Batch and Online MapReduce Computations](http://www.vldb.org/pvldb/vol7/p1441-boykin.pdf),” at *40th International Conference on
+    Very Large Data Bases* (VLDB), September 2014.
 
 1.  Jay Kreps:
-      “[Questioning the Lambda Architecture](https://www.oreilly.com/ideas/questioning-the-lambda-architecture),” *oreilly.com*, July 2, 2014.
+    “[Questioning the Lambda Architecture](https://www.oreilly.com/ideas/questioning-the-lambda-architecture),” *oreilly.com*, July 2, 2014.
 
 1.  Raul Castro Fernandez, Peter Pietzuch, Jay Kreps, et al.:
     “[Liquid: Unifying Nearline and Offline Big Data Integration](http://cidrdb.org/cidr2015/Papers/CIDR15_Paper25u.pdf),”
@@ -69,20 +69,20 @@ Chapter 12 References
     August 2011.
 
 1.  Michael Stonebraker:
-      “[The Case for Polystores](http://wp.sigmod.org/?p=1629),” *wp.sigmod.org*,
-      July 13, 2015.
+    “[The Case for Polystores](http://wp.sigmod.org/?p=1629),” *wp.sigmod.org*,
+    July 13, 2015.
 
 1.  Jennie Duggan,
-      Aaron J. Elmore, Michael Stonebraker, et al.:
-      “[The BigDAWG Polystore System](https://dspace.mit.edu/handle/1721.1/100936),” *ACM SIGMOD Record*, volume 44, number 2, pages 11–16, June 2015.
-      [doi:10.1145/2814710.2814713](http://dx.doi.org/10.1145/2814710.2814713)
+    Aaron J. Elmore, Michael Stonebraker, et al.:
+    “[The BigDAWG Polystore System](https://dspace.mit.edu/handle/1721.1/100936),” *ACM SIGMOD Record*, volume 44, number 2, pages 11–16, June 2015.
+    [doi:10.1145/2814710.2814713](http://dx.doi.org/10.1145/2814710.2814713)
 
 1.  Patrycja Dybka:
-      “[Foreign Data Wrappers for PostgreSQL](http://www.vertabelo.com/blog/technical-articles/foreign-data-wrappers-for-postgresql),” *vertabelo.com*, March 24, 2015.
+    “[Foreign Data Wrappers for PostgreSQL](http://www.vertabelo.com/blog/technical-articles/foreign-data-wrappers-for-postgresql),” *vertabelo.com*, March 24, 2015.
 
 1.  David B. Lomet, Alan Fekete, Gerhard Weikum, and Mike Zwilling:
-      “[Unbundling Transaction Services in the Cloud](https://www.microsoft.com/en-us/research/publication/unbundling-transaction-services-in-the-cloud/),” at *4th Biennial Conference on Innovative Data Systems
-      Research* (CIDR), January 2009.
+    “[Unbundling Transaction Services in the Cloud](https://www.microsoft.com/en-us/research/publication/unbundling-transaction-services-in-the-cloud/),” at *4th Biennial Conference on Innovative Data Systems
+    Research* (CIDR), January 2009.
 
 1.  Martin Kleppmann and Jay Kreps:
     “[Kafka, Samza and the Unix Philosophy of Distributed Data](http://martin.kleppmann.com/papers/kafka-debull15.pdf),” *IEEE Data Engineering Bulletin*, volume 38, number 4, pages 4–14,
@@ -230,17 +230,17 @@ Chapter 12 References
     [doi:10.1145/224056.224070](http://dx.doi.org/10.1145/224056.224070)
 
 1.  Jim Gray:
-      “[The Transaction Concept: Virtues and Limitations](http://jimgray.azurewebsites.net/papers/thetransactionconcept.pdf),”
-      at *7th International Conference on Very Large Data Bases* (VLDB), September 1981.
+    “[The Transaction Concept: Virtues and Limitations](http://jimgray.azurewebsites.net/papers/thetransactionconcept.pdf),”
+    at *7th International Conference on Very Large Data Bases* (VLDB), September 1981.
 
 1.  Hector Garcia-Molina and Kenneth Salem:
-      “[Sagas](http://www.cs.cornell.edu/andru/cs711/2002fa/reading/sagas.pdf),” at
-      *ACM International Conference on Management of Data* (SIGMOD), May 1987.
-      [doi:10.1145/38713.38742](http://dx.doi.org/10.1145/38713.38742)
+    “[Sagas](http://www.cs.cornell.edu/andru/cs711/2002fa/reading/sagas.pdf),” at
+    *ACM International Conference on Management of Data* (SIGMOD), May 1987.
+    [doi:10.1145/38713.38742](http://dx.doi.org/10.1145/38713.38742)
 
 1.  Pat Helland:
-      “[Memories, Guesses, and Apologies](https://web.archive.org/web/20160304020907/http://blogs.msdn.com/b/pathelland/archive/2007/05/15/memories-guesses-and-apologies.aspx),”
-      *blogs.msdn.com*, May 15, 2007.
+    “[Memories, Guesses, and Apologies](https://web.archive.org/web/20160304020907/http://blogs.msdn.com/b/pathelland/archive/2007/05/15/memories-guesses-and-apologies.aspx),”
+    *blogs.msdn.com*, May 15, 2007.
 
 1.  Yoongu Kim, Ross Daly, Jeremie Kim, et al.:
     “[Flipping Bits in Memory Without Accessing Them: An Experimental Study of DRAM Disturbance Errors](https://users.ece.cmu.edu/~yoonguk/papers/kim-isca14.pdf),” at *41st Annual

--- a/chapter-12-refs.md
+++ b/chapter-12-refs.md
@@ -142,8 +142,7 @@ Chapter 12 References
     [doi:10.1145/2723372.2737784](http://dx.doi.org/10.1145/2723372.2737784)
 
 1.  Guy Steele:
-    “[Re: Need for Macros (Was Re: Icon)](https://people.csail.mit.edu/gregs/ll1-discuss-archive-html/msg01134.html),” email to *ll1-discuss* mailing list, *people.csail.mit.edu*, December 24,
-    2001.
+    “[Re: Need for Macros (Was Re: Icon)](https://people.csail.mit.edu/gregs/ll1-discuss-archive-html/msg01134.html),” email to *ll1-discuss* mailing list, *people.csail.mit.edu*, December 24, 2001.
 
 1.  David Gelernter:
     “[Generative Communication in Linda](http://cseweb.ucsd.edu/groups/csag/html/teaching/cse291s03/Readings/p80-gelernter.pdf),” *ACM Transactions on Programming Languages and Systems*
@@ -248,8 +247,7 @@ Chapter 12 References
     [doi:10.1145/2678373.2665726](http://dx.doi.org/10.1145/2678373.2665726)
 
 1.  Mark Seaborn and Thomas Dullien:
-    “[Exploiting the DRAM Rowhammer Bug to Gain Kernel Privileges](https://googleprojectzero.blogspot.co.uk/2015/03/exploiting-dram-rowhammer-bug-to-gain.html),” *googleprojectzero.blogspot.co.uk*, March 9,
-    2015.
+    “[Exploiting the DRAM Rowhammer Bug to Gain Kernel Privileges](https://googleprojectzero.blogspot.co.uk/2015/03/exploiting-dram-rowhammer-bug-to-gain.html),” *googleprojectzero.blogspot.co.uk*, March 9, 2015.
 
 1.  Jim N. Gray and Catharine van Ingen:
     “[Empirical Measurements of Disk Failure Rates and Error Rates](https://www.microsoft.com/en-us/research/publication/empirical-measurements-of-disk-failure-rates-and-error-rates/),” Microsoft Research, MSR-TR-2005-166,
@@ -263,8 +261,7 @@ Chapter 12 References
     *github.com*, September 2015.
 
 1.  Xiao Chen:
-    “[HDFS DataNode Scanners and Disk Checker Explained](http://blog.cloudera.com/blog/2016/12/hdfs-datanode-scanners-and-disk-checker-explained/),” *blog.cloudera.com*, December 20,
-    2016.
+    “[HDFS DataNode Scanners and Disk Checker Explained](http://blog.cloudera.com/blog/2016/12/hdfs-datanode-scanners-and-disk-checker-explained/),” *blog.cloudera.com*, December 20, 2016.
 
 1.  Jay Kreps:
     “[Getting Real About Distributed System Reliability](http://blog.empathybox.com/post/19574936361/getting-real-about-distributed-system-reliability),” *blog.empathybox.com*, March 19, 2012.
@@ -340,15 +337,13 @@ Chapter 12 References
     “[Make Algorithms Accountable](http://www.nytimes.com/2016/08/01/opinion/make-algorithms-accountable.html),” *nytimes.com*, August 1, 2016.
 
 1.  Bryce Goodman and Seth Flaxman:
-    “[European Union Regulations on Algorithmic Decision-Making and a ‘Right to Explanation’](https://arxiv.org/abs/1606.08813),” *arXiv:1606.08813*, August 31,
-    2016.
+    “[European Union Regulations on Algorithmic Decision-Making and a ‘Right to Explanation’](https://arxiv.org/abs/1606.08813),” *arXiv:1606.08813*, August 31, 2016.
 
 1.  “[A Review of the Data Broker Industry: Collection, Use, and Sale of Consumer Data for Marketing Purposes](http://educationnewyork.com/files/rockefeller_databroker.pdf),”
     Staff Report, *United States Senate Committee on Commerce, Science, and Transportation*, *commerce.senate.gov*, December 2013.
 
 1.  Olivia Solon:
-    “[Facebook’s Failure: Did Fake News and Polarized Politics Get Trump Elected?](https://www.theguardian.com/technology/2016/nov/10/facebook-fake-news-election-conspiracy-theories)” *theguardian.com*, November 10,
-    2016.
+    “[Facebook’s Failure: Did Fake News and Polarized Politics Get Trump Elected?](https://www.theguardian.com/technology/2016/nov/10/facebook-fake-news-election-conspiracy-theories)” *theguardian.com*, November 10, 2016.
 
 1.  Donella H. Meadows and Diana Wright:
     *Thinking in Systems: A Primer*. Chelsea Green Publishing, 2008. ISBN: 978-1-603-58055-7
@@ -401,8 +396,7 @@ Chapter 12 References
     [doi:10.14763/2016.1.406](http://dx.doi.org/10.14763/2016.1.406)
 
 1.  Ellen P. Goodman and Julia Powles:
-    “[Facebook and Google: Most Powerful and Secretive Empires We've Ever Known](https://www.theguardian.com/technology/2016/sep/28/google-facebook-powerful-secretive-empire-transparency),” *theguardian.com*, September 28,
-    2016.
+    “[Facebook and Google: Most Powerful and Secretive Empires We've Ever Known](https://www.theguardian.com/technology/2016/sep/28/google-facebook-powerful-secretive-empire-transparency),” *theguardian.com*, September 28, 2016.
 
 1.  [Directive 95/46/EC on the protection of individuals with regard to the processing of personal data and on the free movement of such data](http://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:31995L0046), Official Journal of the European Communities No. L 281/31,
     *eur-lex.europa.eu*, November 1995.
@@ -417,8 +411,7 @@ Chapter 12 References
     [doi:10.14763/2016.1.404](http://dx.doi.org/10.14763/2016.1.404)
 
 1.  Jessica Leber:
-    “[Your Data Footprint Is Affecting Your Life in Ways You Can’t Even Imagine](https://www.fastcoexist.com/3057514/your-data-footprint-is-affecting-your-life-in-ways-you-cant-even-imagine),” *fastcoexist.com*, March 15,
-    2016.
+    “[Your Data Footprint Is Affecting Your Life in Ways You Can’t Even Imagine](https://www.fastcoexist.com/3057514/your-data-footprint-is-affecting-your-life-in-ways-you-cant-even-imagine),” *fastcoexist.com*, March 15, 2016.
 
 1.  Maciej Cegłowski:
     “[Haunted by Data](http://idlewords.com/talks/haunted_by_data.htm),” *idlewords.com*,

--- a/chapter-12-refs.md
+++ b/chapter-12-refs.md
@@ -433,4 +433,3 @@ Chapter 12 References
 
 1.  Phillip Rogaway:
     “[The Moral Character of Cryptographic Work](http://web.cs.ucdavis.edu/~rogaway/papers/moral-fn.pdf),” Cryptology ePrint 2015/1162, December 2015.
-

--- a/chapter-12-refs.md
+++ b/chapter-12-refs.md
@@ -95,7 +95,7 @@ Chapter 12 References
     “[Differential Dataflow](http://cidrdb.org/cidr2013/Papers/CIDR13_Paper111.pdf),”
     at *6th Biennial Conference on Innovative Data Systems Research* (CIDR), January 2013.
 
-1.  Derek G Murray, Frank McSherry, Rebecca Isaacs, et al.:
+1.  Derek G. Murray, Frank McSherry, Rebecca Isaacs, et al.:
     “[Naiad: A Timely Dataflow System](http://sigops.org/s/conferences/sosp/2013/papers/p439-murray.pdf),”
     at *24th ACM Symposium on Operating Systems Principles* (SOSP), pages 439–455, November 2013.
     [doi:10.1145/2517349.2522738](http://dx.doi.org/10.1145/2517349.2522738)
@@ -135,7 +135,7 @@ Chapter 12 References
     “[Machine Learning: The High-Interest Credit Card of Technical Debt](http://research.google.com/pubs/pub43146.html),” at *NIPS Workshop on Software Engineering for Machine Learning*
     (SE4ML), December 2014.
 
-1.  Peter Bailis, Alan Fekete, Michael J Franklin, et al.:
+1.  Peter Bailis, Alan Fekete, Michael J. Franklin, et al.:
     “[Feral Concurrency Control: An Empirical Investigation of Modern Application Integrity](http://www.bailis.org/papers/feral-sigmod2015.pdf),”
     at *ACM International Conference on Management of Data* (SIGMOD), June 2015.
     [doi:10.1145/2723372.2737784](http://dx.doi.org/10.1145/2723372.2737784)
@@ -218,7 +218,7 @@ Chapter 12 References
 1.  Alex Yarmula:
     “[Strong Consistency in Manhattan](https://blog.twitter.com/2016/strong-consistency-in-manhattan),” *blog.twitter.com*, March 17, 2016.
 
-1.  Douglas B Terry, Marvin M Theimer, Karin Petersen, et al.:
+1.  Douglas B. Terry, Marvin M. Theimer, Karin Petersen, et al.:
     “[Managing Update Conflicts in Bayou, a Weakly Connected Replicated Storage System](http://css.csail.mit.edu/6.824/2014/papers/bayou-conflicts.pdf),” at *15th ACM Symposium on Operating
     Systems Principles* (SOSP), pages 172–182, December 1995.
     [doi:10.1145/224056.224070](http://dx.doi.org/10.1145/224056.224070)

--- a/chapter-12-refs.md
+++ b/chapter-12-refs.md
@@ -113,12 +113,11 @@ Chapter 12 References
 1.  “[Juttle Documentation](http://juttle.github.io/juttle/),” *juttle.github.io*, 2016.
 
 1.  Evan Czaplicki and Stephen Chong:
-    “[Asynchronous Functional Reactive Programming for GUIs](http://people.seas.harvard.edu/~chong/pubs/pldi13-elm.pdf),” at *34th ACM SIGPLAN Conference on Programming Language
-    Design and Implementation* (PLDI), June 2013.
+    “[Asynchronous Functional Reactive Programming for GUIs](http://people.seas.harvard.edu/~chong/pubs/pldi13-elm.pdf),”
+    at *34th ACM SIGPLAN Conference on Programming Language Design and Implementation* (PLDI), June 2013.
     [doi:10.1145/2491956.2462161](http://dx.doi.org/10.1145/2491956.2462161)
 
-1.  Engineer Bainomugisha, Andoni Lombide Carreton,
-    Tom van Cutsem, Stijn Mostinckx, and Wolfgang de Meuter:
+1.  Engineer Bainomugisha, Andoni Lombide Carreton, Tom van Cutsem, Stijn Mostinckx, and Wolfgang de Meuter:
     “[A Survey on Reactive Programming](http://soft.vub.ac.be/Publications/2012/vub-soft-tr-12-13.pdf),” *ACM Computing Surveys*, volume 45, number 4, pages 1–34, August 2013.
     [doi:10.1145/2501654.2501666](http://dx.doi.org/10.1145/2501654.2501666)
 
@@ -136,21 +135,20 @@ Chapter 12 References
     “[Machine Learning: The High-Interest Credit Card of Technical Debt](http://research.google.com/pubs/pub43146.html),” at *NIPS Workshop on Software Engineering for Machine Learning*
     (SE4ML), December 2014.
 
-1.  Peter Bailis, Alan Fekete, Michael J Franklin,
-    et al.: “[Feral Concurrency Control: An Empirical Investigation of Modern Application Integrity](http://www.bailis.org/papers/feral-sigmod2015.pdf),” at *ACM International Conference on
-    Management of Data* (SIGMOD), June 2015.
+1.  Peter Bailis, Alan Fekete, Michael J Franklin, et al.:
+    “[Feral Concurrency Control: An Empirical Investigation of Modern Application Integrity](http://www.bailis.org/papers/feral-sigmod2015.pdf),”
+    at *ACM International Conference on Management of Data* (SIGMOD), June 2015.
     [doi:10.1145/2723372.2737784](http://dx.doi.org/10.1145/2723372.2737784)
 
 1.  Guy Steele:
     “[Re: Need for Macros (Was Re: Icon)](https://people.csail.mit.edu/gregs/ll1-discuss-archive-html/msg01134.html),” email to *ll1-discuss* mailing list, *people.csail.mit.edu*, December 24, 2001.
 
 1.  David Gelernter:
-    “[Generative Communication in Linda](http://cseweb.ucsd.edu/groups/csag/html/teaching/cse291s03/Readings/p80-gelernter.pdf),” *ACM Transactions on Programming Languages and Systems*
-    (TOPLAS), volume 7, number 1, pages 80–112, January 1985.
+    “[Generative Communication in Linda](http://cseweb.ucsd.edu/groups/csag/html/teaching/cse291s03/Readings/p80-gelernter.pdf),”
+    *ACM Transactions on Programming Languages and Systems* (TOPLAS), volume 7, number 1, pages 80–112, January 1985.
     [doi:10.1145/2363.2433](http://dx.doi.org/10.1145/2363.2433)
 
-1.  Patrick Th. Eugster, Pascal A. Felber,
-    Rachid Guerraoui, and Anne-Marie Kermarrec:
+1.  Patrick Th. Eugster, Pascal A. Felber, Rachid Guerraoui, and Anne-Marie Kermarrec:
     “[The Many Faces of Publish/Subscribe](http://www.cs.ru.nl/~pieter/oss/manyfaces.pdf),”
     *ACM Computing Surveys*, volume 35, number 2, pages 114–131, June 2003.
     [doi:10.1145/857076.857078](http://dx.doi.org/10.1145/857076.857078)
@@ -165,10 +163,9 @@ Chapter 12 References
     “[Say Hello to Offline First](https://web.archive.org/web/20210420014747/http://hood.ie/blog/say-hello-to-offline-first.html),”
     *hood.ie*, November 5, 2013.
 
-1.  Sebastian Burckhardt, Daan Leijen, Jonathan
-    Protzenko, and Manuel Fähndrich:
-    “[Global Sequence Protocol: A Robust Abstraction for Replicated Shared State](http://drops.dagstuhl.de/opus/volltexte/2015/5238/),” at *29th European Conference on Object-Oriented
-    Programming* (ECOOP), July 2015.
+1.  Sebastian Burckhardt, Daan Leijen, Jonathan Protzenko, and Manuel Fähndrich:
+    “[Global Sequence Protocol: A Robust Abstraction for Replicated Shared State](http://drops.dagstuhl.de/opus/volltexte/2015/5238/),”
+    at *29th European Conference on Object-Oriented Programming* (ECOOP), July 2015.
     [doi:10.4230/LIPIcs.ECOOP.2015.568](http://dx.doi.org/10.4230/LIPIcs.ECOOP.2015.568)
 
 1.  Mark Soper:
@@ -181,15 +178,13 @@ Chapter 12 References
     “[Dataflow as Database](https://github.com/frankmcsherry/blog/blob/master/posts/2016-07-17.md),” *github.com*, July 17, 2016.
 
 1.  Peter Alvaro:
-    “[I See What You Mean](https://www.youtube.com/watch?v=R2Aa4PivG0g),” at *Strange
-    Loop*, September 2015.
+    “[I See What You Mean](https://www.youtube.com/watch?v=R2Aa4PivG0g),” at *Strange Loop*, September 2015.
 
 1.  Nathan Marz:
     “[Trident: A High-Level Abstraction for Realtime Computation](https://blog.twitter.com/2012/trident-a-high-level-abstraction-for-realtime-computation),” *blog.twitter.com*, August 2, 2012.
 
 1.  Edi Bice:
-    “[Low Latency Web Scale Fraud Prevention with Apache Samza, Kafka and Friends](http://www.slideshare.net/edibice/extremely-low-latency-web-scale-fraud-prevention-with-apache-samza-kafka-and-friends),” at *Merchant Risk
-    Council MRC Vegas Conference*, March 2016.
+    “[Low Latency Web Scale Fraud Prevention with Apache Samza, Kafka and Friends](http://www.slideshare.net/edibice/extremely-low-latency-web-scale-fraud-prevention-with-apache-samza-kafka-and-friends),” at *Merchant Risk Council MRC Vegas Conference*, March 2016.
 
 1.  Charity Majors:
     “[The Accidental DBA](https://charity.wtf/2016/10/02/the-accidental-dba/),” *charity.wtf*,
@@ -287,8 +282,8 @@ Chapter 12 References
     [doi:10.1007/3-540-48184-2_32](http://dx.doi.org/10.1007/3-540-48184-2_32)
 
 1.  Ben Laurie:
-    “[Certificate Transparency](http://queue.acm.org/detail.cfm?id=2668154),” *ACM
-    Queue*, volume 12, number 8, pages 10-19, August 2014.
+    “[Certificate Transparency](http://queue.acm.org/detail.cfm?id=2668154),”
+    *ACM Queue*, volume 12, number 8, pages 10-19, August 2014.
     [doi:10.1145/2668152.2668154](http://dx.doi.org/10.1145/2668152.2668154)
 
 1.  Mark D. Ryan:
@@ -309,8 +304,9 @@ Chapter 12 References
     “[Algorithm Writers Need a Code of Conduct](https://www.theguardian.com/commentisfree/2015/dec/06/algorithm-writers-should-have-code-of-conduct),” *theguardian.com*, December 6, 2015.
 
 1.  Logan Kugler:
-    “[What Happens When Big Data Blunders?](http://cacm.acm.org/magazines/2016/6/202655-what-happens-when-big-data-blunders/fulltext),” *Communications of the ACM*, volume 59, number 6, pages
-15–16, June 2016. [doi:10.1145/2911975](http://dx.doi.org/10.1145/2911975)
+    “[What Happens When Big Data Blunders?](http://cacm.acm.org/magazines/2016/6/202655-what-happens-when-big-data-blunders/fulltext),”
+    *Communications of the ACM*, volume 59, number 6, pages 15–16, June 2016.
+    [doi:10.1145/2911975](http://dx.doi.org/10.1145/2911975)
 
 1.  Bill Davidow:
     “[Welcome to Algorithmic Prison](http://www.theatlantic.com/technology/archive/2014/02/welcome-to-algorithmic-prison/283985/),” *theatlantic.com*, February 20, 2014.
@@ -405,8 +401,7 @@ Chapter 12 References
     Thesis, KU Leuven Centre for IT and IP Law, August 2016.
 
 1.  Michiel Rhoen:
-    “[Beyond Consent: Improving Data Protection Through Consumer Protection Law](http://policyreview.info/articles/analysis/beyond-consent-improving-data-protection-through-consumer-protection-law),” *Internet Policy
-    Review*, volume 5, number 1, March 2016.
+    “[Beyond Consent: Improving Data Protection Through Consumer Protection Law](http://policyreview.info/articles/analysis/beyond-consent-improving-data-protection-through-consumer-protection-law),” *Internet Policy Review*, volume 5, number 1, March 2016.
     [doi:10.14763/2016.1.404](http://dx.doi.org/10.14763/2016.1.404)
 
 1.  Jessica Leber:


### PR DESCRIPTION
Changes:
- collapsed non-indentation consecutive spaces
- normalized reference list indentation
- adjusted awkward line breaks
- removed extra trailing newlines

There is one non-whitespace change in 42f7de526e18598e21ab97df5ac787ed9314cd60; it adds periods to middle initials where they are missing.

Although the rendered text will barely change, the source is now more readable and consistent.