### PR TITLE
chore: update DOI links

### DIFF
--- a/chapter-01-refs.md
+++ b/chapter-01-refs.md
@@ -33,7 +33,7 @@ Chapter 1 References
 
 1.  Haryadi S. Gunawi, Mingzhe Hao, Tanakorn
     Leesatapornwongsa, et al.: “[What Bugs Live in the Cloud?](http://ucare.cs.uchicago.edu/pdf/socc14-cbs.pdf),” at *5th ACM Symposium on Cloud Computing* (SoCC), November 2014.
-    [doi:10.1145/2670979.2670986](http://dx.doi.org/10.1145/2670979.2670986)
+    [doi:10.1145/2670979.2670986](https://dx.doi.org/10.1145/2670979.2670986)
 
 1.  Nelson Minar:
       “[Leap Second Crashes Half   the Internet](http://www.somebits.com/weblog/tech/bad/leap-second-2012.html),” *somebits.com*, July 3, 2012.
@@ -88,7 +88,7 @@ Chapter 1 References
 1.  Jeffrey Dean and Luiz André Barroso:
     “[The Tail at Scale](http://cacm.acm.org/magazines/2013/2/160173-the-tail-at-scale/fulltext),”
     *Communications of the ACM*, volume 56, number 2, pages 74–80, February 2013.
-    [doi:10.1145/2408776.2408794](http://dx.doi.org/10.1145/2408776.2408794)
+    [doi:10.1145/2408776.2408794](https://dx.doi.org/10.1145/2408776.2408794)
 
 1.  Graham Cormode, Vladislav
     Shkapenyuk, Divesh Srivastava, and Bojian Xu:
@@ -129,5 +129,4 @@ Chapter 1 References
     “[Analyzing Software Evolvability](http://www.es.mdh.se/pdf_publications/1251.pdf),”
     at *32nd Annual IEEE International Computer Software and Applications Conference*
     (COMPSAC), July 2008.
-    [doi:10.1109/COMPSAC.2008.50](http://dx.doi.org/10.1109/COMPSAC.2008.50)
-
+    [doi:10.1109/COMPSAC.2008.50](https://dx.doi.org/10.1109/COMPSAC.2008.50)

--- a/chapter-01-refs.md
+++ b/chapter-01-refs.md
@@ -33,7 +33,7 @@ Chapter 1 References
 
 1.  Haryadi S. Gunawi, Mingzhe Hao, Tanakorn
     Leesatapornwongsa, et al.: “[What Bugs Live in the Cloud?](http://ucare.cs.uchicago.edu/pdf/socc14-cbs.pdf),” at *5th ACM Symposium on Cloud Computing* (SoCC), November 2014.
-    [doi:10.1145/2670979.2670986](https://dx.doi.org/10.1145/2670979.2670986)
+    [doi:10.1145/2670979.2670986](https://doi.org/10.1145/2670979.2670986)
 
 1.  Nelson Minar:
       “[Leap Second Crashes Half   the Internet](http://www.somebits.com/weblog/tech/bad/leap-second-2012.html),” *somebits.com*, July 3, 2012.
@@ -88,7 +88,7 @@ Chapter 1 References
 1.  Jeffrey Dean and Luiz André Barroso:
     “[The Tail at Scale](http://cacm.acm.org/magazines/2013/2/160173-the-tail-at-scale/fulltext),”
     *Communications of the ACM*, volume 56, number 2, pages 74–80, February 2013.
-    [doi:10.1145/2408776.2408794](https://dx.doi.org/10.1145/2408776.2408794)
+    [doi:10.1145/2408776.2408794](https://doi.org/10.1145/2408776.2408794)
 
 1.  Graham Cormode, Vladislav
     Shkapenyuk, Divesh Srivastava, and Bojian Xu:
@@ -129,4 +129,4 @@ Chapter 1 References
     “[Analyzing Software Evolvability](http://www.es.mdh.se/pdf_publications/1251.pdf),”
     at *32nd Annual IEEE International Computer Software and Applications Conference*
     (COMPSAC), July 2008.
-    [doi:10.1109/COMPSAC.2008.50](https://dx.doi.org/10.1109/COMPSAC.2008.50)
+    [doi:10.1109/COMPSAC.2008.50](https://doi.org/10.1109/COMPSAC.2008.50)

--- a/chapter-02-refs.md
+++ b/chapter-02-refs.md
@@ -7,7 +7,7 @@ Chapter 2 References
 1.  Edgar F. Codd:
     “[A Relational Model of Data for Large Shared Data Banks](https://www.seas.upenn.edu/~zives/03f/cis550/codd.pdf),” *Communications of the ACM*, volume 13, number
     6, pages 377–387, June 1970.
-    [doi:10.1145/362384.362685](http://dx.doi.org/10.1145/362384.362685)
+    [doi:10.1145/362384.362685](https://dx.doi.org/10.1145/362384.362685)
 
 1.  Michael Stonebraker and Joseph M. Hellerstein:
     “[What Goes Around Comes Around](http://mitpress2.mit.edu/books/chapters/0262693143chapm1.pdf),”
@@ -61,12 +61,12 @@ Chapter 2 References
 1.  Charles W. Bachman:
     “[The Programmer as Navigator](http://dl.acm.org/citation.cfm?id=362534),”
     *Communications of the ACM*, volume 16, number 11, pages 653–658, November 1973.
-    [doi:10.1145/355611.362534](http://dx.doi.org/10.1145/355611.362534)
+    [doi:10.1145/355611.362534](https://dx.doi.org/10.1145/355611.362534)
 
 1.  Joseph M. Hellerstein, Michael Stonebraker, and James Hamilton:
     “[Architecture of a Database System](http://db.cs.berkeley.edu/papers/fntdb07-architecture.pdf),”
     *Foundations and Trends in Databases*, volume 1, number 2, pages 141–259, November 2007.
-    [doi:10.1561/1900000002](http://dx.doi.org/10.1561/1900000002)
+    [doi:10.1561/1900000002](https://dx.doi.org/10.1561/1900000002)
 
 1.  Sandeep Parikh and Kelly Stirman:
     “[Schema Design for Time Series Data in MongoDB](http://blog.mongodb.org/post/65517193370/schema-design-for-time-series-data-in-mongodb),” *blog.mongodb.org*, October 30, 2013.
@@ -157,12 +157,12 @@ Chapter 2 References
 1.  Todd J. Green, Shan Shan Huang, Boon Thau Loo, and Wenchao Zhou:
     “[Datalog and Recursive Query Processing](http://blogs.evergreen.edu/sosw/files/2014/04/Green-Vol5-DBS-017.pdf),” *Foundations and Trends in Databases*,
     volume 5, number 2, pages 105–195, November 2013.
-    [doi:10.1561/1900000017](http://dx.doi.org/10.1561/1900000017)
+    [doi:10.1561/1900000017](https://dx.doi.org/10.1561/1900000017)
 
 1.  Stefano Ceri, Georg Gottlob, and Letizia Tanca:
     “[What You Always Wanted to Know About Datalog (And Never Dared to Ask)](https://www.researchgate.net/profile/Letizia_Tanca/publication/3296132_What_you_always_wanted_to_know_about_Datalog_and_never_dared_to_ask/links/0fcfd50ca2d20473ca000000.pdf),” *IEEE
     Transactions on Knowledge and Data Engineering*, volume 1, number 1, pages 146–166, March 1989.
-    [doi:10.1109/69.43410](http://dx.doi.org/10.1109/69.43410)
+    [doi:10.1109/69.43410](https://dx.doi.org/10.1109/69.43410)
 
 1.  Serge Abiteboul, Richard Hull, and Victor Vianu:
     [*Foundations of Databases*](http://webdam.inria.fr/Alice/). Addison-Wesley, 1995.
@@ -175,9 +175,8 @@ Chapter 2 References
       Ilene Karsch-Mizrachi, David J. Lipman, et al.:
       “[GenBank](https://academic.oup.com/nar/article/36/suppl_1/D25/2507746),”
       *Nucleic Acids Research*, volume 36, Database issue, pages D25–D30, December 2007.
-      [doi:10.1093/nar/gkm929](http://dx.doi.org/10.1093/nar/gkm929)
+      [doi:10.1093/nar/gkm929](https://dx.doi.org/10.1093/nar/gkm929)
 
 1.  Fons Rademakers:
       “[ROOT for Big Data Analysis](https://indico.cern.ch/event/246453/contributions/1566610/attachments/423154/587535/ROOT-BigData-Analysis-London-2013.pdf),” at *Workshop on the Future of Big Data Management*,
       London, UK, June 2013.
-

--- a/chapter-02-refs.md
+++ b/chapter-02-refs.md
@@ -7,7 +7,7 @@ Chapter 2 References
 1.  Edgar F. Codd:
     “[A Relational Model of Data for Large Shared Data Banks](https://www.seas.upenn.edu/~zives/03f/cis550/codd.pdf),” *Communications of the ACM*, volume 13, number
     6, pages 377–387, June 1970.
-    [doi:10.1145/362384.362685](https://dx.doi.org/10.1145/362384.362685)
+    [doi:10.1145/362384.362685](https://doi.org/10.1145/362384.362685)
 
 1.  Michael Stonebraker and Joseph M. Hellerstein:
     “[What Goes Around Comes Around](http://mitpress2.mit.edu/books/chapters/0262693143chapm1.pdf),”
@@ -61,12 +61,12 @@ Chapter 2 References
 1.  Charles W. Bachman:
     “[The Programmer as Navigator](http://dl.acm.org/citation.cfm?id=362534),”
     *Communications of the ACM*, volume 16, number 11, pages 653–658, November 1973.
-    [doi:10.1145/355611.362534](https://dx.doi.org/10.1145/355611.362534)
+    [doi:10.1145/355611.362534](https://doi.org/10.1145/355611.362534)
 
 1.  Joseph M. Hellerstein, Michael Stonebraker, and James Hamilton:
     “[Architecture of a Database System](http://db.cs.berkeley.edu/papers/fntdb07-architecture.pdf),”
     *Foundations and Trends in Databases*, volume 1, number 2, pages 141–259, November 2007.
-    [doi:10.1561/1900000002](https://dx.doi.org/10.1561/1900000002)
+    [doi:10.1561/1900000002](https://doi.org/10.1561/1900000002)
 
 1.  Sandeep Parikh and Kelly Stirman:
     “[Schema Design for Time Series Data in MongoDB](http://blog.mongodb.org/post/65517193370/schema-design-for-time-series-data-in-mongodb),” *blog.mongodb.org*, October 30, 2013.
@@ -157,12 +157,12 @@ Chapter 2 References
 1.  Todd J. Green, Shan Shan Huang, Boon Thau Loo, and Wenchao Zhou:
     “[Datalog and Recursive Query Processing](http://blogs.evergreen.edu/sosw/files/2014/04/Green-Vol5-DBS-017.pdf),” *Foundations and Trends in Databases*,
     volume 5, number 2, pages 105–195, November 2013.
-    [doi:10.1561/1900000017](https://dx.doi.org/10.1561/1900000017)
+    [doi:10.1561/1900000017](https://doi.org/10.1561/1900000017)
 
 1.  Stefano Ceri, Georg Gottlob, and Letizia Tanca:
     “[What You Always Wanted to Know About Datalog (And Never Dared to Ask)](https://www.researchgate.net/profile/Letizia_Tanca/publication/3296132_What_you_always_wanted_to_know_about_Datalog_and_never_dared_to_ask/links/0fcfd50ca2d20473ca000000.pdf),” *IEEE
     Transactions on Knowledge and Data Engineering*, volume 1, number 1, pages 146–166, March 1989.
-    [doi:10.1109/69.43410](https://dx.doi.org/10.1109/69.43410)
+    [doi:10.1109/69.43410](https://doi.org/10.1109/69.43410)
 
 1.  Serge Abiteboul, Richard Hull, and Victor Vianu:
     [*Foundations of Databases*](http://webdam.inria.fr/Alice/). Addison-Wesley, 1995.
@@ -175,7 +175,7 @@ Chapter 2 References
       Ilene Karsch-Mizrachi, David J. Lipman, et al.:
       “[GenBank](https://academic.oup.com/nar/article/36/suppl_1/D25/2507746),”
       *Nucleic Acids Research*, volume 36, Database issue, pages D25–D30, December 2007.
-      [doi:10.1093/nar/gkm929](https://dx.doi.org/10.1093/nar/gkm929)
+      [doi:10.1093/nar/gkm929](https://doi.org/10.1093/nar/gkm929)
 
 1.  Fons Rademakers:
       “[ROOT for Big Data Analysis](https://indico.cern.ch/event/246453/contributions/1566610/attachments/423154/587535/ROOT-BigData-Analysis-London-2013.pdf),” at *Workshop on the Future of Big Data Management*,

--- a/chapter-03-refs.md
+++ b/chapter-03-refs.md
@@ -22,7 +22,7 @@ Chapter 3 References
 1.  Goetz Graefe:
       “[Modern B-Tree Techniques](https://w6113.github.io/files/papers/btreesurvey-graefe.pdf),”
       *Foundations and Trends in Databases*, volume 3, number 4, pages 203–402, August 2011.
-      [doi:10.1561/1900000028](https://dx.doi.org/10.1561/1900000028)
+      [doi:10.1561/1900000028](https://doi.org/10.1561/1900000028)
 
 1.  Jeffrey Dean and Sanjay Ghemawat:
     “[LevelDB Implementation Notes](https://github.com/google/leveldb/blob/master/doc/impl.md),”
@@ -43,12 +43,12 @@ Chapter 3 References
     O'Neil, Edward Cheng, Dieter Gawlick, and Elizabeth O'Neil:
     “[The Log-Structured Merge-Tree (LSM-Tree)](http://www.cs.umb.edu/~poneil/lsmtree.pdf),”
     *Acta Informatica*, volume 33, number 4, pages 351–385, June 1996.
-    [doi:10.1007/s002360050048](https://dx.doi.org/10.1007/s002360050048)
+    [doi:10.1007/s002360050048](https://doi.org/10.1007/s002360050048)
 
 1.  Mendel Rosenblum and John K. Ousterhout:
     “[The Design and Implementation of a Log-Structured File System](http://research.cs.wisc.edu/areas/os/Qual/papers/lfs.pdf),”
     *ACM Transactions on Computer Systems*, volume 10, number 1, pages 26–52, February 1992.
-    [doi:10.1145/146941.146943](https://dx.doi.org/10.1145/146941.146943)
+    [doi:10.1145/146941.146943](https://doi.org/10.1145/146941.146943)
 
 1.  Adrien Grand:
     “[What Is in a Lucene Index?](http://www.slideshare.net/lucenerevolution/what-is-inaluceneagrandfinal),” at *Lucene/Solr Revolution*, November 14, 2013.
@@ -62,7 +62,7 @@ Chapter 3 References
 1.  Burton H. Bloom:
     “[Space/Time Trade-offs in Hash Coding with Allowable Errors](https://people.cs.umass.edu/~emery/classes/cmpsci691st/readings/Misc/p422-bloom.pdf),”
     *Communications of the ACM*, volume 13, number 7, pages 422–426, July 1970.
-    [doi:10.1145/362686.362692](https://dx.doi.org/10.1145/362686.362692)
+    [doi:10.1145/362686.362692](https://doi.org/10.1145/362686.362692)
 
 1.  “[Operating Cassandra: Compaction](https://cassandra.apache.org/doc/latest/operating/compaction/index.html),” Apache Cassandra Documentation v4.0, 2016.
 
@@ -72,7 +72,7 @@ Chapter 3 References
 
 1.  Douglas Comer:
     “[The Ubiquitous B-Tree](http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.96.6637&rep=rep1&type=pdf),” *ACM Computing Surveys*, volume 11, number 2, pages 121–137, June 1979.
-    [doi:10.1145/356770.356776](https://dx.doi.org/10.1145/356770.356776)
+    [doi:10.1145/356770.356776](https://doi.org/10.1145/356770.356776)
 
 1.  Emmanuel Goossaert:
     “[Coding for SSDs](http://codecapsule.com/2014/02/12/coding-for-ssds-part-1-introduction-and-table-of-contents/),” *codecapsule.com*, February 12, 2014.
@@ -80,7 +80,7 @@ Chapter 3 References
 1.  C. Mohan and Frank Levine:
     “[ARIES/IM: An Efficient and High Concurrency Index Management Method Using Write-Ahead Logging](http://www.ics.uci.edu/~cs223/papers/p371-mohan.pdf),” at *ACM
     International Conference on Management of Data* (SIGMOD), June 1992.
-    [doi:10.1145/130283.130338](https://dx.doi.org/10.1145/130283.130338)
+    [doi:10.1145/130283.130338](https://doi.org/10.1145/130283.130338)
 
 1.  Howard Chu:
       “[LDAP at Lightning Speed]( https://buildstuff14.sched.com/event/08a1a368e272eb599a52e08b4c3c779d),”
@@ -93,7 +93,7 @@ Chapter 3 References
 1.  Manos Athanassoulis, Michael S. Kester,
     Lukas M. Maas, et al.: “[Designing Access Methods: The RUM Conjecture](http://openproceedings.org/2016/conf/edbt/paper-12.pdf),” at *19th International Conference on Extending Database
     Technology* (EDBT), March 2016.
-    [doi:10.5441/002/edbt.2016.42](https://dx.doi.org/10.5441/002/edbt.2016.42)
+    [doi:10.5441/002/edbt.2016.42](https://doi.org/10.5441/002/edbt.2016.42)
 
 1.  Peter Zaitsev:
     “[Innodb Double Write](https://www.percona.com/blog/2006/08/04/innodb-double-write/),”
@@ -136,7 +136,7 @@ Chapter 3 References
 
 1.  Robert Escriva, Bernard Wong, and Emin Gün Sirer:
     “[HyperDex: A Distributed, Searchable Key-Value Store](http://www.cs.princeton.edu/courses/archive/fall13/cos518/papers/hyperdex.pdf),” at *ACM SIGCOMM Conference*, August 2012.
-    [doi:10.1145/2377677.2377681](https://dx.doi.org/10.1145/2377677.2377681)
+    [doi:10.1145/2377677.2377681](https://doi.org/10.1145/2377677.2377681)
 
 1.  Michael McCandless:
     “[Lucene's FuzzyQuery Is 100 Times Faster in 4.0](http://blog.mikemccandless.com/2011/03/lucenes-fuzzyquery-is-100-times-faster.html),” *blog.mikemccandless.com*, March 24, 2011.
@@ -144,13 +144,13 @@ Chapter 3 References
 1.  Steffen Heinz, Justin Zobel, and Hugh E. Williams:
     “[Burst Tries: A Fast, Efficient Data Structure for String Keys](http://citeseer.ist.psu.edu/viewdoc/summary?doi=10.1.1.18.3499),”
     *ACM Transactions on Information Systems*, volume 20, number 2, pages 192–223, April 2002.
-    [doi:10.1145/506309.506312](https://dx.doi.org/10.1145/506309.506312)
+    [doi:10.1145/506309.506312](https://doi.org/10.1145/506309.506312)
 
 1.  Klaus U. Schulz and Stoyan Mihov:
     “[Fast String Correction with Levenshtein Automata](http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.16.652),”
     *International Journal on Document Analysis and Recognition*,
     volume 5, number 1, pages 67–85, November 2002.
-    [doi:10.1007/s10032-002-0082-8](https://dx.doi.org/10.1007/s10032-002-0082-8)
+    [doi:10.1007/s10032-002-0082-8](https://doi.org/10.1007/s10032-002-0082-8)
 
 1.  Christopher D. Manning, Prabhakar Raghavan, and Hinrich Schütze:
     [*Introduction to Information Retrieval*](http://nlp.stanford.edu/IR-book/).
@@ -170,7 +170,7 @@ Chapter 3 References
     Samuel Madden, and Michael Stonebraker:
     “[OLTP Through the Looking Glass, and What We Found There](http://hstore.cs.brown.edu/papers/hstore-lookingglass.pdf),” at *ACM International Conference on Management of Data*
     (SIGMOD), June 2008.
-    [doi:10.1145/1376616.1376713](https://dx.doi.org/10.1145/1376616.1376713)
+    [doi:10.1145/1376616.1376713](https://doi.org/10.1145/1376616.1376713)
 
 1.  Justin DeBrabant, Andrew Pavlo, Stephen Tu, et al.:
     “[Anti-Caching: A New Approach to Database Management System Architecture](http://www.vldb.org/pvldb/vol6/p1942-debrabant.pdf),” *Proceedings of the VLDB Endowment*, volume 6,
@@ -179,7 +179,7 @@ Chapter 3 References
 1.  Joy Arulraj, Andrew Pavlo, and Subramanya R. Dulloor:
     “[Let's Talk About Storage & Recovery Methods for Non-Volatile Memory Database Systems](http://www.pdl.cmu.edu/PDL-FTP/NVM/storage.pdf),” at *ACM International Conference on
     Management of Data* (SIGMOD), June 2015.
-    [doi:10.1145/2723372.2749441](https://dx.doi.org/10.1145/2723372.2749441)
+    [doi:10.1145/2723372.2749441](https://doi.org/10.1145/2723372.2749441)
 
 1.  Edgar F. Codd, S. B. Codd, and C. T. Salley:
     “[Providing OLAP to User-Analysts: An IT Mandate](https://pdfs.semanticscholar.org/a0bd/1491a54a4de428c5eef9b836ef6ee2915fe7.pdf),”
@@ -187,7 +187,7 @@ Chapter 3 References
 
 1.  Surajit Chaudhuri and Umeshwar Dayal:
     “[An Overview of Data Warehousing and OLAP Technology](https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/sigrecord.pdf),” *ACM SIGMOD Record*, volume 26, number 1, pages 65–74,
-    March 1997. [doi:10.1145/248603.248616](https://dx.doi.org/10.1145/248603.248616)
+    March 1997. [doi:10.1145/248603.248616](https://doi.org/10.1145/248603.248616)
 
 1.  Per-Åke Larson, Cipri Clinciu, Campbell Fraser, et al.:
     “[Enhancements to SQL Server Column Stores](http://research.microsoft.com/pubs/193599/Apollo3%20-%20Sigmod%202013%20-%20final.pdf),” at *ACM International Conference on Management of Data*
@@ -227,7 +227,7 @@ Chapter 3 References
     Harizopoulos, et al.:
     “[The Design and Implementation of Modern Column-Oriented Database Systems](http://cs-www.cs.yale.edu/homes/dna/papers/abadi-column-stores.pdf),” *Foundations and Trends in
     Databases*, volume 5, number 3, pages 197–280, December 2013.
-    [doi:10.1561/1900000024](https://dx.doi.org/10.1561/1900000024)
+    [doi:10.1561/1900000024](https://doi.org/10.1561/1900000024)
 
 1.  Peter Boncz, Marcin Zukowski, and Niels Nes:
     “[MonetDB/X100: Hyper-Pipelining Query Execution](http://cidrdb.org/cidr2005/papers/P19.pdf),”
@@ -236,7 +236,7 @@ Chapter 3 References
 1.  Jingren Zhou and Kenneth A. Ross:
     “[Implementing Database Operations Using SIMD Instructions](http://www1.cs.columbia.edu/~kar/pubsk/simd.pdf),”
     at *ACM International Conference on Management of Data* (SIGMOD), pages 145–156, June 2002.
-    [doi:10.1145/564691.564709](https://dx.doi.org/10.1145/564691.564709)
+    [doi:10.1145/564691.564709](https://doi.org/10.1145/564691.564709)
 
 1.  Michael Stonebraker, Daniel J. Abadi, Adam Batkin, et al.:
     “[C-Store: A Column-oriented DBMS](http://www.cs.umd.edu/~abadi/vldb.pdf),”
@@ -253,4 +253,4 @@ Chapter 3 References
 1.  Jim Gray, Surajit Chaudhuri, Adam Bosworth, et al.:
     “[Data Cube: A Relational Aggregation Operator Generalizing Group-By, Cross-Tab, and Sub-Totals](http://arxiv.org/pdf/cs/0701155.pdf),” *Data Mining and Knowledge
     Discovery*, volume 1, number 1, pages 29–53, March 2007.
-    [doi:10.1023/A:1009726021843](https://dx.doi.org/10.1023/A:1009726021843)
+    [doi:10.1023/A:1009726021843](https://doi.org/10.1023/A:1009726021843)

--- a/chapter-03-refs.md
+++ b/chapter-03-refs.md
@@ -22,7 +22,7 @@ Chapter 3 References
 1.  Goetz Graefe:
       “[Modern B-Tree Techniques](https://w6113.github.io/files/papers/btreesurvey-graefe.pdf),”
       *Foundations and Trends in Databases*, volume 3, number 4, pages 203–402, August 2011.
-      [doi:10.1561/1900000028](http://dx.doi.org/10.1561/1900000028)
+      [doi:10.1561/1900000028](https://dx.doi.org/10.1561/1900000028)
 
 1.  Jeffrey Dean and Sanjay Ghemawat:
     “[LevelDB Implementation Notes](https://github.com/google/leveldb/blob/master/doc/impl.md),”
@@ -43,12 +43,12 @@ Chapter 3 References
     O'Neil, Edward Cheng, Dieter Gawlick, and Elizabeth O'Neil:
     “[The Log-Structured Merge-Tree (LSM-Tree)](http://www.cs.umb.edu/~poneil/lsmtree.pdf),”
     *Acta Informatica*, volume 33, number 4, pages 351–385, June 1996.
-    [doi:10.1007/s002360050048](http://dx.doi.org/10.1007/s002360050048)
+    [doi:10.1007/s002360050048](https://dx.doi.org/10.1007/s002360050048)
 
 1.  Mendel Rosenblum and John K. Ousterhout:
     “[The Design and Implementation of a Log-Structured File System](http://research.cs.wisc.edu/areas/os/Qual/papers/lfs.pdf),”
     *ACM Transactions on Computer Systems*, volume 10, number 1, pages 26–52, February 1992.
-    [doi:10.1145/146941.146943](http://dx.doi.org/10.1145/146941.146943)
+    [doi:10.1145/146941.146943](https://dx.doi.org/10.1145/146941.146943)
 
 1.  Adrien Grand:
     “[What Is in a Lucene Index?](http://www.slideshare.net/lucenerevolution/what-is-inaluceneagrandfinal),” at *Lucene/Solr Revolution*, November 14, 2013.
@@ -62,7 +62,7 @@ Chapter 3 References
 1.  Burton H. Bloom:
     “[Space/Time Trade-offs in Hash Coding with Allowable Errors](https://people.cs.umass.edu/~emery/classes/cmpsci691st/readings/Misc/p422-bloom.pdf),”
     *Communications of the ACM*, volume 13, number 7, pages 422–426, July 1970.
-    [doi:10.1145/362686.362692](http://dx.doi.org/10.1145/362686.362692)
+    [doi:10.1145/362686.362692](https://dx.doi.org/10.1145/362686.362692)
 
 1.  “[Operating Cassandra: Compaction](https://cassandra.apache.org/doc/latest/operating/compaction/index.html),” Apache Cassandra Documentation v4.0, 2016.
 
@@ -72,7 +72,7 @@ Chapter 3 References
 
 1.  Douglas Comer:
     “[The Ubiquitous B-Tree](http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.96.6637&rep=rep1&type=pdf),” *ACM Computing Surveys*, volume 11, number 2, pages 121–137, June 1979.
-    [doi:10.1145/356770.356776](http://dx.doi.org/10.1145/356770.356776)
+    [doi:10.1145/356770.356776](https://dx.doi.org/10.1145/356770.356776)
 
 1.  Emmanuel Goossaert:
     “[Coding for SSDs](http://codecapsule.com/2014/02/12/coding-for-ssds-part-1-introduction-and-table-of-contents/),” *codecapsule.com*, February 12, 2014.
@@ -80,7 +80,7 @@ Chapter 3 References
 1.  C. Mohan and Frank Levine:
     “[ARIES/IM: An Efficient and High Concurrency Index Management Method Using Write-Ahead Logging](http://www.ics.uci.edu/~cs223/papers/p371-mohan.pdf),” at *ACM
     International Conference on Management of Data* (SIGMOD), June 1992.
-    [doi:10.1145/130283.130338](http://dx.doi.org/10.1145/130283.130338)
+    [doi:10.1145/130283.130338](https://dx.doi.org/10.1145/130283.130338)
 
 1.  Howard Chu:
       “[LDAP at Lightning Speed]( https://buildstuff14.sched.com/event/08a1a368e272eb599a52e08b4c3c779d),”
@@ -93,7 +93,7 @@ Chapter 3 References
 1.  Manos Athanassoulis, Michael S. Kester,
     Lukas M. Maas, et al.: “[Designing Access Methods: The RUM Conjecture](http://openproceedings.org/2016/conf/edbt/paper-12.pdf),” at *19th International Conference on Extending Database
     Technology* (EDBT), March 2016.
-    [doi:10.5441/002/edbt.2016.42](http://dx.doi.org/10.5441/002/edbt.2016.42)
+    [doi:10.5441/002/edbt.2016.42](https://dx.doi.org/10.5441/002/edbt.2016.42)
 
 1.  Peter Zaitsev:
     “[Innodb Double Write](https://www.percona.com/blog/2006/08/04/innodb-double-write/),”
@@ -136,7 +136,7 @@ Chapter 3 References
 
 1.  Robert Escriva, Bernard Wong, and Emin Gün Sirer:
     “[HyperDex: A Distributed, Searchable Key-Value Store](http://www.cs.princeton.edu/courses/archive/fall13/cos518/papers/hyperdex.pdf),” at *ACM SIGCOMM Conference*, August 2012.
-    [doi:10.1145/2377677.2377681](http://dx.doi.org/10.1145/2377677.2377681)
+    [doi:10.1145/2377677.2377681](https://dx.doi.org/10.1145/2377677.2377681)
 
 1.  Michael McCandless:
     “[Lucene's FuzzyQuery Is 100 Times Faster in 4.0](http://blog.mikemccandless.com/2011/03/lucenes-fuzzyquery-is-100-times-faster.html),” *blog.mikemccandless.com*, March 24, 2011.
@@ -144,13 +144,13 @@ Chapter 3 References
 1.  Steffen Heinz, Justin Zobel, and Hugh E. Williams:
     “[Burst Tries: A Fast, Efficient Data Structure for String Keys](http://citeseer.ist.psu.edu/viewdoc/summary?doi=10.1.1.18.3499),”
     *ACM Transactions on Information Systems*, volume 20, number 2, pages 192–223, April 2002.
-    [doi:10.1145/506309.506312](http://dx.doi.org/10.1145/506309.506312)
+    [doi:10.1145/506309.506312](https://dx.doi.org/10.1145/506309.506312)
 
 1.  Klaus U. Schulz and Stoyan Mihov:
     “[Fast String Correction with Levenshtein Automata](http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.16.652),”
     *International Journal on Document Analysis and Recognition*,
     volume 5, number 1, pages 67–85, November 2002.
-    [doi:10.1007/s10032-002-0082-8](http://dx.doi.org/10.1007/s10032-002-0082-8)
+    [doi:10.1007/s10032-002-0082-8](https://dx.doi.org/10.1007/s10032-002-0082-8)
 
 1.  Christopher D. Manning, Prabhakar Raghavan, and Hinrich Schütze:
     [*Introduction to Information Retrieval*](http://nlp.stanford.edu/IR-book/).
@@ -170,7 +170,7 @@ Chapter 3 References
     Samuel Madden, and Michael Stonebraker:
     “[OLTP Through the Looking Glass, and What We Found There](http://hstore.cs.brown.edu/papers/hstore-lookingglass.pdf),” at *ACM International Conference on Management of Data*
     (SIGMOD), June 2008.
-    [doi:10.1145/1376616.1376713](http://dx.doi.org/10.1145/1376616.1376713)
+    [doi:10.1145/1376616.1376713](https://dx.doi.org/10.1145/1376616.1376713)
 
 1.  Justin DeBrabant, Andrew Pavlo, Stephen Tu, et al.:
     “[Anti-Caching: A New Approach to Database Management System Architecture](http://www.vldb.org/pvldb/vol6/p1942-debrabant.pdf),” *Proceedings of the VLDB Endowment*, volume 6,
@@ -179,7 +179,7 @@ Chapter 3 References
 1.  Joy Arulraj, Andrew Pavlo, and Subramanya R. Dulloor:
     “[Let's Talk About Storage & Recovery Methods for Non-Volatile Memory Database Systems](http://www.pdl.cmu.edu/PDL-FTP/NVM/storage.pdf),” at *ACM International Conference on
     Management of Data* (SIGMOD), June 2015.
-    [doi:10.1145/2723372.2749441](http://dx.doi.org/10.1145/2723372.2749441)
+    [doi:10.1145/2723372.2749441](https://dx.doi.org/10.1145/2723372.2749441)
 
 1.  Edgar F. Codd, S. B. Codd, and C. T. Salley:
     “[Providing OLAP to User-Analysts: An IT Mandate](https://pdfs.semanticscholar.org/a0bd/1491a54a4de428c5eef9b836ef6ee2915fe7.pdf),”
@@ -187,7 +187,7 @@ Chapter 3 References
 
 1.  Surajit Chaudhuri and Umeshwar Dayal:
     “[An Overview of Data Warehousing and OLAP Technology](https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/sigrecord.pdf),” *ACM SIGMOD Record*, volume 26, number 1, pages 65–74,
-    March 1997. [doi:10.1145/248603.248616](http://dx.doi.org/10.1145/248603.248616)
+    March 1997. [doi:10.1145/248603.248616](https://dx.doi.org/10.1145/248603.248616)
 
 1.  Per-Åke Larson, Cipri Clinciu, Campbell Fraser, et al.:
     “[Enhancements to SQL Server Column Stores](http://research.microsoft.com/pubs/193599/Apollo3%20-%20Sigmod%202013%20-%20final.pdf),” at *ACM International Conference on Management of Data*
@@ -227,7 +227,7 @@ Chapter 3 References
     Harizopoulos, et al.:
     “[The Design and Implementation of Modern Column-Oriented Database Systems](http://cs-www.cs.yale.edu/homes/dna/papers/abadi-column-stores.pdf),” *Foundations and Trends in
     Databases*, volume 5, number 3, pages 197–280, December 2013.
-    [doi:10.1561/1900000024](http://dx.doi.org/10.1561/1900000024)
+    [doi:10.1561/1900000024](https://dx.doi.org/10.1561/1900000024)
 
 1.  Peter Boncz, Marcin Zukowski, and Niels Nes:
     “[MonetDB/X100: Hyper-Pipelining Query Execution](http://cidrdb.org/cidr2005/papers/P19.pdf),”
@@ -236,7 +236,7 @@ Chapter 3 References
 1.  Jingren Zhou and Kenneth A. Ross:
     “[Implementing Database Operations Using SIMD Instructions](http://www1.cs.columbia.edu/~kar/pubsk/simd.pdf),”
     at *ACM International Conference on Management of Data* (SIGMOD), pages 145–156, June 2002.
-    [doi:10.1145/564691.564709](http://dx.doi.org/10.1145/564691.564709)
+    [doi:10.1145/564691.564709](https://dx.doi.org/10.1145/564691.564709)
 
 1.  Michael Stonebraker, Daniel J. Abadi, Adam Batkin, et al.:
     “[C-Store: A Column-oriented DBMS](http://www.cs.umd.edu/~abadi/vldb.pdf),”
@@ -253,5 +253,4 @@ Chapter 3 References
 1.  Jim Gray, Surajit Chaudhuri, Adam Bosworth, et al.:
     “[Data Cube: A Relational Aggregation Operator Generalizing Group-By, Cross-Tab, and Sub-Totals](http://arxiv.org/pdf/cs/0701155.pdf),” *Data Mining and Knowledge
     Discovery*, volume 1, number 1, pages 29–53, March 2007.
-    [doi:10.1023/A:1009726021843](http://dx.doi.org/10.1023/A:1009726021843)
-
+    [doi:10.1023/A:1009726021843](https://dx.doi.org/10.1023/A:1009726021843)

--- a/chapter-04-refs.md
+++ b/chapter-04-refs.md
@@ -127,12 +127,12 @@ Chapter 4 References
 1.  Michi Henning:
     “[The Rise and Fall of CORBA](https://cacm.acm.org/magazines/2008/8/5336-the-rise-and-fall-of-corba/fulltext),”
     *Communications of the ACM*, volume 51, number 8, pages 52–57, August 2008.
-    [doi:10.1145/1378704.1378718](https://dx.doi.org/10.1145/1378704.1378718)
+    [doi:10.1145/1378704.1378718](https://doi.org/10.1145/1378704.1378718)
 
 1.  Andrew D. Birrell and Bruce Jay Nelson:
     “[Implementing Remote Procedure Calls](http://www.cs.princeton.edu/courses/archive/fall03/cs518/papers/rpc.pdf),” *ACM Transactions on Computer Systems* (TOCS),
     volume 2, number 1, pages 39–59, February 1984.
-    [doi:10.1145/2080.357392](https://dx.doi.org/10.1145/2080.357392)
+    [doi:10.1145/2080.357392](https://doi.org/10.1145/2080.357392)
 
 1.  Jim Waldo, Geoff Wyant, Ann Wollrath, and Sam Kendall:
     “[A Note on Distributed Computing](http://m.mirror.facebook.net/kde/devel/smli_tr-94-29.pdf),”
@@ -140,12 +140,12 @@ Chapter 4 References
 
 1.  Steve Vinoski:
     “[Convenience over Correctness](http://steve.vinoski.net/pdf/IEEE-Convenience_Over_Correctness.pdf),” *IEEE Internet Computing*, volume 12, number 4, pages 89–92, July 2008.
-    [doi:10.1109/MIC.2008.75](https://dx.doi.org/10.1109/MIC.2008.75)
+    [doi:10.1109/MIC.2008.75](https://doi.org/10.1109/MIC.2008.75)
 
 1.  Marius Eriksen:
     “[Your Server as a Function](http://monkey.org/~marius/funsrv.pdf),” at
     *7th Workshop on Programming Languages and Operating Systems* (PLOS), November 2013.
-    [doi:10.1145/2525528.2525538](https://dx.doi.org/10.1145/2525528.2525538)
+    [doi:10.1145/2525528.2525538](https://doi.org/10.1145/2525528.2525538)
 
 1.  “[gRPC concepts](https://grpc.io/docs/guides/concepts/),” The Linux Foundation, *grpc.io*.
 

--- a/chapter-04-refs.md
+++ b/chapter-04-refs.md
@@ -127,12 +127,12 @@ Chapter 4 References
 1.  Michi Henning:
     “[The Rise and Fall of CORBA](https://cacm.acm.org/magazines/2008/8/5336-the-rise-and-fall-of-corba/fulltext),”
     *Communications of the ACM*, volume 51, number 8, pages 52–57, August 2008.
-    [doi:10.1145/1378704.1378718](http://dx.doi.org/10.1145/1378704.1378718)
+    [doi:10.1145/1378704.1378718](https://dx.doi.org/10.1145/1378704.1378718)
 
 1.  Andrew D. Birrell and Bruce Jay Nelson:
     “[Implementing Remote Procedure Calls](http://www.cs.princeton.edu/courses/archive/fall03/cs518/papers/rpc.pdf),” *ACM Transactions on Computer Systems* (TOCS),
     volume 2, number 1, pages 39–59, February 1984.
-    [doi:10.1145/2080.357392](http://dx.doi.org/10.1145/2080.357392)
+    [doi:10.1145/2080.357392](https://dx.doi.org/10.1145/2080.357392)
 
 1.  Jim Waldo, Geoff Wyant, Ann Wollrath, and Sam Kendall:
     “[A Note on Distributed Computing](http://m.mirror.facebook.net/kde/devel/smli_tr-94-29.pdf),”
@@ -140,12 +140,12 @@ Chapter 4 References
 
 1.  Steve Vinoski:
     “[Convenience over Correctness](http://steve.vinoski.net/pdf/IEEE-Convenience_Over_Correctness.pdf),” *IEEE Internet Computing*, volume 12, number 4, pages 89–92, July 2008.
-    [doi:10.1109/MIC.2008.75](http://dx.doi.org/10.1109/MIC.2008.75)
+    [doi:10.1109/MIC.2008.75](https://dx.doi.org/10.1109/MIC.2008.75)
 
 1.  Marius Eriksen:
     “[Your Server as a Function](http://monkey.org/~marius/funsrv.pdf),” at
     *7th Workshop on Programming Languages and Operating Systems* (PLOS), November 2013.
-    [doi:10.1145/2525528.2525538](http://dx.doi.org/10.1145/2525528.2525538)
+    [doi:10.1145/2525528.2525538](https://dx.doi.org/10.1145/2525528.2525538)
 
 1.  “[gRPC concepts](https://grpc.io/docs/guides/concepts/),” The Linux Foundation, *grpc.io*.
 
@@ -174,4 +174,3 @@ Chapter 4 References
 1.  Fred Hebert:
       “[Postscript: Maps](http://learnyousomeerlang.com/maps),” *learnyousomeerlang.com*,
       April 9, 2014.
-

--- a/chapter-05-refs.md
+++ b/chapter-05-refs.md
@@ -73,7 +73,7 @@ Chapter 5 References
 1.  Werner Vogels:
     “[Eventually Consistent](http://queue.acm.org/detail.cfm?id=1466448),”
     *ACM Queue*, volume 6, number 6, pages 14–19, October 2008.
-    [doi:10.1145/1466443.1466448](https://dx.doi.org/10.1145/1466443.1466448)
+    [doi:10.1145/1466443.1466448](https://doi.org/10.1145/1466443.1466448)
 
 1.  Douglas B. Terry:
     “[Replicated Data Consistency Explained Through Baseball](https://www.microsoft.com/en-us/research/publication/replicated-data-consistency-explained-through-baseball/),” Microsoft Research, Technical Report
@@ -82,7 +82,7 @@ Chapter 5 References
 1.  Douglas B. Terry, Alan J. Demers, Karin Petersen, et al.:
     “[Session Guarantees for Weakly Consistent Replicated Data](http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.71.2269&rep=rep1&type=pdf),” at *3rd International Conference
     on Parallel and Distributed Information Systems* (PDIS), September 1994.
-    [doi:10.1109/PDIS.1994.331722](https://dx.doi.org/10.1109/PDIS.1994.331722)
+    [doi:10.1109/PDIS.1994.331722](https://doi.org/10.1109/PDIS.1994.331722)
 
 1.  Terry Pratchett: *Reaper Man: A Discworld
     Novel*. Victor Gollancz, 1991. ISBN: 978-0-575-04979-6
@@ -151,7 +151,7 @@ Chapter 5 References
 1.  David K. Gifford:
     “[Weighted Voting for Replicated Data](https://www.cs.cmu.edu/~15-749/READINGS/required/availability/gifford79.pdf),”
     at *7th ACM Symposium on Operating Systems Principles* (SOSP), December 1979.
-    [doi:10.1145/800215.806583](https://dx.doi.org/10.1145/800215.806583)
+    [doi:10.1145/800215.806583](https://doi.org/10.1145/800215.806583)
 
 1.  Heidi Howard, Dahlia Malkhi, and Alexander Spiegelman:
     “[Flexible Paxos: Quorum Intersection Revisited](https://arxiv.org/abs/1608.06696),”
@@ -169,7 +169,7 @@ Chapter 5 References
     Michael J. Franklin, et al.:
     “[Quantifying Eventual Consistency with PBS](http://www.bailis.org/papers/pbs-cacm2014.pdf),”
     *Communications of the ACM*, volume 57, number 8, pages 93–102, August 2014.
-    [doi:10.1145/2632792](https://dx.doi.org/10.1145/2632792)
+    [doi:10.1145/2632792](https://doi.org/10.1145/2632792)
 
 1.  Jonathan Ellis:
     “[Modern Hinted Handoff](http://www.datastax.com/dev/blog/modern-hinted-handoff),”
@@ -188,7 +188,7 @@ Chapter 5 References
 1.  Leslie Lamport:
     “[Time, Clocks, and the Ordering of Events in a Distributed System](https://www.microsoft.com/en-us/research/publication/time-clocks-ordering-events-distributed-system/),” *Communications of the ACM*,
     volume 21, number 7, pages 558–565, July 1978.
-    [doi:10.1145/359545.359563](https://dx.doi.org/10.1145/359545.359563)
+    [doi:10.1145/359545.359563](https://doi.org/10.1145/359545.359563)
 
 1.  Joel Jacobson:
     “[Riak 2.0: Data Types](https://web.archive.org/web/20160327135816/http://blog.joeljacobson.com/riak-2-0-data-types/),”
@@ -197,7 +197,7 @@ Chapter 5 References
 1.  D. Stott Parker Jr., Gerald J. Popek, Gerard Rudisin, et al.:
     “[Detection of Mutual Inconsistency in Distributed Systems](https://web.archive.org/web/20170808212704/https://zoo.cs.yale.edu/classes/cs426/2013/bib/parker83detection.pdf),” *IEEE Transactions on Software Engineering*,
     volume 9, number 3, pages 240–247, May 1983.
-    [doi:10.1109/TSE.1983.236733](https://dx.doi.org/10.1109/TSE.1983.236733)
+    [doi:10.1109/TSE.1983.236733](https://doi.org/10.1109/TSE.1983.236733)
 
 1.  Nuno Preguiça, Carlos Baquero, Paulo Sérgio
     Almeida, et al.: “[Dotted Version Vectors: Logical Clocks for Optimistic Replication](http://arxiv.org/pdf/1011.5808v1.pdf),” arXiv:1011.5808, November 26,
@@ -216,4 +216,4 @@ Chapter 5 References
 1.  Reinhard Schwarz and Friedemann Mattern:
     “[Detecting Causal Relationships in Distributed Computations: In Search of the Holy Grail](http://dcg.ethz.ch/lectures/hs08/seminar/papers/mattern4.pdf),” *Distributed
     Computing*, volume 7, number 3, pages 149–174, March 1994.
-    [doi:10.1007/BF02277859](https://dx.doi.org/10.1007/BF02277859)
+    [doi:10.1007/BF02277859](https://doi.org/10.1007/BF02277859)

--- a/chapter-05-refs.md
+++ b/chapter-05-refs.md
@@ -73,7 +73,7 @@ Chapter 5 References
 1.  Werner Vogels:
     “[Eventually Consistent](http://queue.acm.org/detail.cfm?id=1466448),”
     *ACM Queue*, volume 6, number 6, pages 14–19, October 2008.
-    [doi:10.1145/1466443.1466448](http://dx.doi.org/10.1145/1466443.1466448)
+    [doi:10.1145/1466443.1466448](https://dx.doi.org/10.1145/1466443.1466448)
 
 1.  Douglas B. Terry:
     “[Replicated Data Consistency Explained Through Baseball](https://www.microsoft.com/en-us/research/publication/replicated-data-consistency-explained-through-baseball/),” Microsoft Research, Technical Report
@@ -82,7 +82,7 @@ Chapter 5 References
 1.  Douglas B. Terry, Alan J. Demers, Karin Petersen, et al.:
     “[Session Guarantees for Weakly Consistent Replicated Data](http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.71.2269&rep=rep1&type=pdf),” at *3rd International Conference
     on Parallel and Distributed Information Systems* (PDIS), September 1994.
-    [doi:10.1109/PDIS.1994.331722](http://dx.doi.org/10.1109/PDIS.1994.331722)
+    [doi:10.1109/PDIS.1994.331722](https://dx.doi.org/10.1109/PDIS.1994.331722)
 
 1.  Terry Pratchett: *Reaper Man: A Discworld
     Novel*. Victor Gollancz, 1991. ISBN: 978-0-575-04979-6
@@ -151,7 +151,7 @@ Chapter 5 References
 1.  David K. Gifford:
     “[Weighted Voting for Replicated Data](https://www.cs.cmu.edu/~15-749/READINGS/required/availability/gifford79.pdf),”
     at *7th ACM Symposium on Operating Systems Principles* (SOSP), December 1979.
-    [doi:10.1145/800215.806583](http://dx.doi.org/10.1145/800215.806583)
+    [doi:10.1145/800215.806583](https://dx.doi.org/10.1145/800215.806583)
 
 1.  Heidi Howard, Dahlia Malkhi, and Alexander Spiegelman:
     “[Flexible Paxos: Quorum Intersection Revisited](https://arxiv.org/abs/1608.06696),”
@@ -169,7 +169,7 @@ Chapter 5 References
     Michael J. Franklin, et al.:
     “[Quantifying Eventual Consistency with PBS](http://www.bailis.org/papers/pbs-cacm2014.pdf),”
     *Communications of the ACM*, volume 57, number 8, pages 93–102, August 2014.
-    [doi:10.1145/2632792](http://dx.doi.org/10.1145/2632792)
+    [doi:10.1145/2632792](https://dx.doi.org/10.1145/2632792)
 
 1.  Jonathan Ellis:
     “[Modern Hinted Handoff](http://www.datastax.com/dev/blog/modern-hinted-handoff),”
@@ -188,7 +188,7 @@ Chapter 5 References
 1.  Leslie Lamport:
     “[Time, Clocks, and the Ordering of Events in a Distributed System](https://www.microsoft.com/en-us/research/publication/time-clocks-ordering-events-distributed-system/),” *Communications of the ACM*,
     volume 21, number 7, pages 558–565, July 1978.
-    [doi:10.1145/359545.359563](http://dx.doi.org/10.1145/359545.359563)
+    [doi:10.1145/359545.359563](https://dx.doi.org/10.1145/359545.359563)
 
 1.  Joel Jacobson:
     “[Riak 2.0: Data Types](https://web.archive.org/web/20160327135816/http://blog.joeljacobson.com/riak-2-0-data-types/),”
@@ -197,7 +197,7 @@ Chapter 5 References
 1.  D. Stott Parker Jr., Gerald J. Popek, Gerard Rudisin, et al.:
     “[Detection of Mutual Inconsistency in Distributed Systems](https://web.archive.org/web/20170808212704/https://zoo.cs.yale.edu/classes/cs426/2013/bib/parker83detection.pdf),” *IEEE Transactions on Software Engineering*,
     volume 9, number 3, pages 240–247, May 1983.
-    [doi:10.1109/TSE.1983.236733](http://dx.doi.org/10.1109/TSE.1983.236733)
+    [doi:10.1109/TSE.1983.236733](https://dx.doi.org/10.1109/TSE.1983.236733)
 
 1.  Nuno Preguiça, Carlos Baquero, Paulo Sérgio
     Almeida, et al.: “[Dotted Version Vectors: Logical Clocks for Optimistic Replication](http://arxiv.org/pdf/1011.5808v1.pdf),” arXiv:1011.5808, November 26,
@@ -216,5 +216,4 @@ Chapter 5 References
 1.  Reinhard Schwarz and Friedemann Mattern:
     “[Detecting Causal Relationships in Distributed Computations: In Search of the Holy Grail](http://dcg.ethz.ch/lectures/hs08/seminar/papers/mattern4.pdf),” *Distributed
     Computing*, volume 7, number 3, pages 149–174, March 1994.
-    [doi:10.1007/BF02277859](http://dx.doi.org/10.1007/BF02277859)
-
+    [doi:10.1007/BF02277859](https://dx.doi.org/10.1007/BF02277859)

--- a/chapter-06-refs.md
+++ b/chapter-06-refs.md
@@ -7,7 +7,7 @@ Chapter 6 References
 1.  David J. DeWitt and Jim N. Gray:
     “[Parallel Database Systems: The Future of High Performance Database Systems](http://www.cs.cmu.edu/~pavlo/courses/fall2013/static/papers/dewittgray92.pdf),”
     *Communications of the ACM*, volume 35, number 6, pages 85–98, June 1992.
-    [doi:10.1145/129888.129894](https://dx.doi.org/10.1145/129888.129894)
+    [doi:10.1145/129888.129894](https://doi.org/10.1145/129888.129894)
 
 1.  Lars George:
     “[HBase vs. BigTable Comparison](http://www.larsgeorge.com/2009/11/hbase-vs-bigtable-comparison.html),”
@@ -28,7 +28,7 @@ Chapter 6 References
 1.  David Karger, Eric Lehman, Tom Leighton, et al.:
     “[Consistent Hashing and Random Trees: Distributed Caching Protocols for Relieving Hot Spots on the World Wide Web](https://www.akamai.com/site/en/documents/research-paper/consistent-hashing-and-random-trees-distributed-caching-protocols-for-relieving-hot-spots-on-the-world-wide-web-technical-publication.pdf),”
     at *29th Annual ACM Symposium on Theory of Computing* (STOC), pages 654–663, 1997.
-    [doi:10.1145/258533.258660](https://dx.doi.org/10.1145/258533.258660)
+    [doi:10.1145/258533.258660](https://doi.org/10.1145/258533.258660)
 
 1.  John Lamping and Eric Veach:
     “[A Fast, Minimal Memory, Consistent Hash Algorithm](http://arxiv.org/pdf/1406.2294.pdf),” *arxiv.org*, June 2014.
@@ -101,11 +101,11 @@ Chapter 6 References
 
 1.  Kishore Gopalakrishna, Shi Lu, Zhen Zhang, et al.:
     “[Untangling Cluster Management with Helix](http://www.socc2012.org/helix_onecol.pdf?attredirects=0),” at *ACM Symposium on Cloud Computing* (SoCC), October 2012.
-    [doi:10.1145/2391229.2391248](https://dx.doi.org/10.1145/2391229.2391248)
+    [doi:10.1145/2391229.2391248](https://doi.org/10.1145/2391229.2391248)
 
 1.  “[Moxi 1.8 Manual](http://docs.couchbase.com/moxi-manual-1.8/),” Couchbase, Inc., 2014.
 
 1.  Shivnath Babu and Herodotos Herodotou:
     “[Massively Parallel Databases and MapReduce Systems](https://www.microsoft.com/en-us/research/wp-content/uploads/2013/11/db-mr-survey-final.pdf),”
     *Foundations and Trends in Databases*, volume 5, number 1, pages 1–104, November 2013.
-    [doi:10.1561/1900000036](https://dx.doi.org/10.1561/1900000036)
+    [doi:10.1561/1900000036](https://doi.org/10.1561/1900000036)

--- a/chapter-06-refs.md
+++ b/chapter-06-refs.md
@@ -7,7 +7,7 @@ Chapter 6 References
 1.  David J. DeWitt and Jim N. Gray:
     “[Parallel Database Systems: The Future of High Performance Database Systems](http://www.cs.cmu.edu/~pavlo/courses/fall2013/static/papers/dewittgray92.pdf),”
     *Communications of the ACM*, volume 35, number 6, pages 85–98, June 1992.
-    [doi:10.1145/129888.129894](http://dx.doi.org/10.1145/129888.129894)
+    [doi:10.1145/129888.129894](https://dx.doi.org/10.1145/129888.129894)
 
 1.  Lars George:
     “[HBase vs. BigTable Comparison](http://www.larsgeorge.com/2009/11/hbase-vs-bigtable-comparison.html),”
@@ -28,7 +28,7 @@ Chapter 6 References
 1.  David Karger, Eric Lehman, Tom Leighton, et al.:
     “[Consistent Hashing and Random Trees: Distributed Caching Protocols for Relieving Hot Spots on the World Wide Web](https://www.akamai.com/site/en/documents/research-paper/consistent-hashing-and-random-trees-distributed-caching-protocols-for-relieving-hot-spots-on-the-world-wide-web-technical-publication.pdf),”
     at *29th Annual ACM Symposium on Theory of Computing* (STOC), pages 654–663, 1997.
-    [doi:10.1145/258533.258660](http://dx.doi.org/10.1145/258533.258660)
+    [doi:10.1145/258533.258660](https://dx.doi.org/10.1145/258533.258660)
 
 1.  John Lamping and Eric Veach:
     “[A Fast, Minimal Memory, Consistent Hash Algorithm](http://arxiv.org/pdf/1406.2294.pdf),” *arxiv.org*, June 2014.
@@ -101,12 +101,11 @@ Chapter 6 References
 
 1.  Kishore Gopalakrishna, Shi Lu, Zhen Zhang, et al.:
     “[Untangling Cluster Management with Helix](http://www.socc2012.org/helix_onecol.pdf?attredirects=0),” at *ACM Symposium on Cloud Computing* (SoCC), October 2012.
-    [doi:10.1145/2391229.2391248](http://dx.doi.org/10.1145/2391229.2391248)
+    [doi:10.1145/2391229.2391248](https://dx.doi.org/10.1145/2391229.2391248)
 
 1.  “[Moxi 1.8 Manual](http://docs.couchbase.com/moxi-manual-1.8/),” Couchbase, Inc., 2014.
 
 1.  Shivnath Babu and Herodotos Herodotou:
     “[Massively Parallel Databases and MapReduce Systems](https://www.microsoft.com/en-us/research/wp-content/uploads/2013/11/db-mr-survey-final.pdf),”
     *Foundations and Trends in Databases*, volume 5, number 1, pages 1–104, November 2013.
-    [doi:10.1561/1900000036](http://dx.doi.org/10.1561/1900000036)
-
+    [doi:10.1561/1900000036](https://dx.doi.org/10.1561/1900000036)

--- a/chapter-07-refs.md
+++ b/chapter-07-refs.md
@@ -7,7 +7,7 @@ Chapter 7 References
 1.  Donald D. Chamberlin, Morton M. Astrahan, Michael W. Blasgen, et al.:
     “[A History and Evaluation of System R](https://citeseerx.ist.psu.edu/pdf/ebb29a0ca16e04e7eeb6b606b22a9eadb3a9d531),” *Communications of the ACM*,
     volume 24, number 10, pages 632–646, October 1981.
-    [doi:10.1145/358769.358784](https://dx.doi.org/10.1145/358769.358784)
+    [doi:10.1145/358769.358784](https://doi.org/10.1145/358769.358784)
 
 1.  Jim N. Gray, Raymond A. Lorie, Gianfranco R. Putzolu, and Irving L. Traiger:
     “[Granularity of Locks and Degrees of Consistency in a Shared Data Base](https://citeseerx.ist.psu.edu/pdf/e127f0a6a912bb9150ecfe03c0ebf7fbc289a023),” in *Modelling in Data
@@ -31,7 +31,7 @@ Chapter 7 References
 1.  Theo Härder and Andreas Reuter:
     “[Principles of Transaction-Oriented Database Recovery](https://citeseerx.ist.psu.edu/pdf/11ef7c142295aeb1a28a0e714c91fc8d610c3047),” *ACM Computing Surveys*,
     volume 15, number 4, pages 287–317, December 1983.
-    [doi:10.1145/289.291](https://dx.doi.org/10.1145/289.291)
+    [doi:10.1145/289.291](https://doi.org/10.1145/289.291)
 
 1.  Peter Bailis, Alan Fekete, Ali Ghodsi, et al.:
     “[HAT, not CAP: Towards Highly Available Transactions](http://www.bailis.org/papers/hat-hotos2013.pdf),”
@@ -48,7 +48,7 @@ Chapter 7 References
 1.  Alan Fekete, Dimitrios Liarokapis, Elizabeth O'Neil, et al.:
     “[Making Snapshot Isolation Serializable](https://www.cse.iitb.ac.in/infolab/Data/Courses/CS632/2009/Papers/p492-fekete.pdf),” *ACM Transactions on Database Systems*,
     volume 30, number 2, pages 492–528, June 2005.
-    [doi:10.1145/1071610.1071615](https://dx.doi.org/10.1145/1071610.1071615)
+    [doi:10.1145/1071610.1071615](https://doi.org/10.1145/1071610.1071615)
 
 1.  Mai Zheng, Joseph Tucek, Feng Qin, and Mark Lillibridge:
       “[Understanding the Robustness of SSDs Under Power Fault](https://www.usenix.org/system/files/conference/fast13/fast13-final80.pdf),” at *11th USENIX Conference on File and
@@ -157,7 +157,7 @@ Chapter 7 References
 1.  Michael J. Cahill, Uwe Röhm, and Alan Fekete:
     “[Serializable Isolation for Snapshot Databases](https://web.archive.org/web/20200709144151/https://cs.nyu.edu/courses/Fall12/CSCI-GA.2434-001/p729-cahill.pdf),” at *ACM International Conference on
     Management of Data* (SIGMOD), June 2008.
-    [doi:10.1145/1376616.1376690](https://dx.doi.org/10.1145/1376616.1376690)
+    [doi:10.1145/1376616.1376690](https://doi.org/10.1145/1376616.1376690)
 
 1.  Dan R. K. Ports and Kevin Grittner:
     “[Serializable Snapshot Isolation in PostgreSQL](http://drkp.net/papers/ssi-vldb12.pdf),”
@@ -169,7 +169,7 @@ Chapter 7 References
 1.  Douglas B. Terry, Marvin M. Theimer, Karin Petersen, et al.:
       “[Managing Update Conflicts in Bayou, a Weakly Connected Replicated Storage System](https://citeseerx.ist.psu.edu/pdf/20c450f099b661c5a2dff3f348773a0d1af1b09b),” at
       *15th ACM Symposium on Operating Systems Principles* (SOSP), December 1995.
-      [doi:10.1145/224056.224070](https://dx.doi.org/10.1145/224056.224070)
+      [doi:10.1145/224056.224070](https://doi.org/10.1145/224056.224070)
 
 1.  Gary Fredericks:
       “[Postgres Serializability Bug](https://github.com/gfredericks/pg-serializability-bug),” *github.com*, September 2015.
@@ -195,7 +195,7 @@ Chapter 7 References
 1.  Joseph M. Hellerstein, Michael Stonebraker, and James Hamilton:
     “[Architecture of a Database System](https://dsf.berkeley.edu/papers/fntdb07-architecture.pdf),”
     *Foundations and Trends in Databases*, volume 1, number 2, pages 141–259, November 2007.
-    [doi:10.1561/1900000002](https://dx.doi.org/10.1561/1900000002)
+    [doi:10.1561/1900000002](https://doi.org/10.1561/1900000002)
 
 1.  Michael J. Cahill:
     “[Serializable Isolation for Snapshot Databases](https://ses.library.usyd.edu.au/bitstream/handle/2123/5353/michael-cahill-2009-thesis.pdf),” PhD Thesis, University of Sydney, July 2009.
@@ -207,7 +207,7 @@ Chapter 7 References
 1.  Rakesh Agrawal, Michael J. Carey, and Miron Livny:
     “[Concurrency Control Performance Modeling: Alternatives and Implications](http://www.eecs.berkeley.edu/~brewer/cs262/ConcControl.pdf),” *ACM Transactions on Database
     Systems* (TODS), volume 12, number 4, pages 609–654, December 1987.
-    [doi:10.1145/32204.32220](https://dx.doi.org/10.1145/32204.32220)
+    [doi:10.1145/32204.32220](https://doi.org/10.1145/32204.32220)
 
 1.  Dave Rosenthal:
     “[Databases at 14.4MHz](http://web.archive.org/web/20150427041746/http://blog.foundationdb.com/databases-at-14.4mhz),”

--- a/chapter-07-refs.md
+++ b/chapter-07-refs.md
@@ -7,7 +7,7 @@ Chapter 7 References
 1.  Donald D. Chamberlin, Morton M. Astrahan, Michael W. Blasgen, et al.:
     “[A History and Evaluation of System R](https://citeseerx.ist.psu.edu/pdf/ebb29a0ca16e04e7eeb6b606b22a9eadb3a9d531),” *Communications of the ACM*,
     volume 24, number 10, pages 632–646, October 1981.
-    [doi:10.1145/358769.358784](http://dx.doi.org/10.1145/358769.358784)
+    [doi:10.1145/358769.358784](https://dx.doi.org/10.1145/358769.358784)
 
 1.  Jim N. Gray, Raymond A. Lorie, Gianfranco R. Putzolu, and Irving L. Traiger:
     “[Granularity of Locks and Degrees of Consistency in a Shared Data Base](https://citeseerx.ist.psu.edu/pdf/e127f0a6a912bb9150ecfe03c0ebf7fbc289a023),” in *Modelling in Data
@@ -31,7 +31,7 @@ Chapter 7 References
 1.  Theo Härder and Andreas Reuter:
     “[Principles of Transaction-Oriented Database Recovery](https://citeseerx.ist.psu.edu/pdf/11ef7c142295aeb1a28a0e714c91fc8d610c3047),” *ACM Computing Surveys*,
     volume 15, number 4, pages 287–317, December 1983.
-    [doi:10.1145/289.291](http://dx.doi.org/10.1145/289.291)
+    [doi:10.1145/289.291](https://dx.doi.org/10.1145/289.291)
 
 1.  Peter Bailis, Alan Fekete, Ali Ghodsi, et al.:
     “[HAT, not CAP: Towards Highly Available Transactions](http://www.bailis.org/papers/hat-hotos2013.pdf),”
@@ -48,7 +48,7 @@ Chapter 7 References
 1.  Alan Fekete, Dimitrios Liarokapis, Elizabeth O'Neil, et al.:
     “[Making Snapshot Isolation Serializable](https://www.cse.iitb.ac.in/infolab/Data/Courses/CS632/2009/Papers/p492-fekete.pdf),” *ACM Transactions on Database Systems*,
     volume 30, number 2, pages 492–528, June 2005.
-    [doi:10.1145/1071610.1071615](http://dx.doi.org/10.1145/1071610.1071615)
+    [doi:10.1145/1071610.1071615](https://dx.doi.org/10.1145/1071610.1071615)
 
 1.  Mai Zheng, Joseph Tucek, Feng Qin, and Mark Lillibridge:
       “[Understanding the Robustness of SSDs Under Power Fault](https://www.usenix.org/system/files/conference/fast13/fast13-final80.pdf),” at *11th USENIX Conference on File and
@@ -157,7 +157,7 @@ Chapter 7 References
 1.  Michael J. Cahill, Uwe Röhm, and Alan Fekete:
     “[Serializable Isolation for Snapshot Databases](https://web.archive.org/web/20200709144151/https://cs.nyu.edu/courses/Fall12/CSCI-GA.2434-001/p729-cahill.pdf),” at *ACM International Conference on
     Management of Data* (SIGMOD), June 2008.
-    [doi:10.1145/1376616.1376690](http://dx.doi.org/10.1145/1376616.1376690)
+    [doi:10.1145/1376616.1376690](https://dx.doi.org/10.1145/1376616.1376690)
 
 1.  Dan R. K. Ports and Kevin Grittner:
     “[Serializable Snapshot Isolation in PostgreSQL](http://drkp.net/papers/ssi-vldb12.pdf),”
@@ -169,7 +169,7 @@ Chapter 7 References
 1.  Douglas B. Terry, Marvin M. Theimer, Karin Petersen, et al.:
       “[Managing Update Conflicts in Bayou, a Weakly Connected Replicated Storage System](https://citeseerx.ist.psu.edu/pdf/20c450f099b661c5a2dff3f348773a0d1af1b09b),” at
       *15th ACM Symposium on Operating Systems Principles* (SOSP), December 1995.
-      [doi:10.1145/224056.224070](http://dx.doi.org/10.1145/224056.224070)
+      [doi:10.1145/224056.224070](https://dx.doi.org/10.1145/224056.224070)
 
 1.  Gary Fredericks:
       “[Postgres Serializability Bug](https://github.com/gfredericks/pg-serializability-bug),” *github.com*, September 2015.
@@ -195,7 +195,7 @@ Chapter 7 References
 1.  Joseph M. Hellerstein, Michael Stonebraker, and James Hamilton:
     “[Architecture of a Database System](https://dsf.berkeley.edu/papers/fntdb07-architecture.pdf),”
     *Foundations and Trends in Databases*, volume 1, number 2, pages 141–259, November 2007.
-    [doi:10.1561/1900000002](http://dx.doi.org/10.1561/1900000002)
+    [doi:10.1561/1900000002](https://dx.doi.org/10.1561/1900000002)
 
 1.  Michael J. Cahill:
     “[Serializable Isolation for Snapshot Databases](https://ses.library.usyd.edu.au/bitstream/handle/2123/5353/michael-cahill-2009-thesis.pdf),” PhD Thesis, University of Sydney, July 2009.
@@ -207,9 +207,8 @@ Chapter 7 References
 1.  Rakesh Agrawal, Michael J. Carey, and Miron Livny:
     “[Concurrency Control Performance Modeling: Alternatives and Implications](http://www.eecs.berkeley.edu/~brewer/cs262/ConcControl.pdf),” *ACM Transactions on Database
     Systems* (TODS), volume 12, number 4, pages 609–654, December 1987.
-    [doi:10.1145/32204.32220](http://dx.doi.org/10.1145/32204.32220)
+    [doi:10.1145/32204.32220](https://dx.doi.org/10.1145/32204.32220)
 
 1.  Dave Rosenthal:
     “[Databases at 14.4MHz](http://web.archive.org/web/20150427041746/http://blog.foundationdb.com/databases-at-14.4mhz),”
     *blog.foundationdb.com*, December 10, 2014.
-

--- a/chapter-08-refs.md
+++ b/chapter-08-refs.md
@@ -6,7 +6,7 @@ Chapter 8 References
 
 1.  Mark Cavage:
     “[There’s Just No Getting Around It: You’re Building a Distributed System](http://queue.acm.org/detail.cfm?id=2482856),” *ACM Queue*, volume 11, number 4, pages 80-89, April 2013.
-    [doi:10.1145/2466486.2482856](http://dx.doi.org/10.1145/2466486.2482856)
+    [doi:10.1145/2466486.2482856](https://dx.doi.org/10.1145/2466486.2482856)
 
 1.  Jay Kreps:
     “[Getting Real About Distributed System Reliability](http://blog.empathybox.com/post/19574936361/getting-real-about-distributed-system-reliability),” *blog.empathybox.com*, March 19, 2012.
@@ -28,7 +28,7 @@ Chapter 8 References
     “[The Datacenter as a Computer: An Introduction to the Design of Warehouse-Scale Machines, Second Edition](https://web.archive.org/web/20140404113735/http://www.morganclaypool.com/doi/abs/10.2200/S00516ED2V01Y201306CAC024),”
     *Synthesis Lectures on Computer Architecture*, volume 8, number 3,
     Morgan & Claypool Publishers, July 2013.
-    [doi:10.2200/S00516ED2V01Y201306CAC024](http://dx.doi.org/10.2200/S00516ED2V01Y201306CAC024),
+    [doi:10.2200/S00516ED2V01Y201306CAC024](https://dx.doi.org/10.2200/S00516ED2V01Y201306CAC024),
     ISBN: 978-1-627-05010-4
 
 1.  David Fiala, Frank Mueller, Christian Engelmann, et al.:
@@ -39,7 +39,7 @@ Chapter 8 References
 1.  Arjun Singh, Joon Ong, Amit Agarwal, et al.:
       “[Jupiter Rising: A Decade of Clos Topologies and Centralized Control in Google’s Datacenter Network](http://conferences.sigcomm.org/sigcomm/2015/pdf/papers/p183.pdf),” at
       *Annual Conference of the ACM Special Interest Group on Data Communication* (SIGCOMM), August 2015.
-      [doi:10.1145/2785956.2787508](http://dx.doi.org/10.1145/2785956.2787508)
+      [doi:10.1145/2785956.2787508](https://dx.doi.org/10.1145/2785956.2787508)
 
 1.  Glenn K. Lockwood:
       “[Hadoop's Uncomfortable Fit in HPC](http://glennklockwood.blogspot.co.uk/2014/05/hadoops-uncomfortable-fit-in-hpc.html),” *glennklockwood.blogspot.co.uk*, May 16, 2014.
@@ -60,17 +60,17 @@ Chapter 8 References
 1.  Peter Bailis and Kyle Kingsbury:
     “[The Network Is Reliable](https://queue.acm.org/detail.cfm?id=2655736),”
     *ACM Queue*, volume 12, number 7, pages 48-55, July 2014.
-    [doi:10.1145/2639988.2639988](http://dx.doi.org/10.1145/2639988.2639988)
+    [doi:10.1145/2639988.2639988](https://dx.doi.org/10.1145/2639988.2639988)
 
 1.  Joshua B. Leners, Trinabh Gupta, Marcos K. Aguilera, and Michael Walfish:
     “[Taming Uncertainty in Distributed Systems with Help from the Network](http://www.cs.nyu.edu/~mwalfish/papers/albatross-eurosys15.pdf),” at *10th European Conference on
     Computer Systems* (EuroSys), April 2015.
-    [doi:10.1145/2741948.2741976](http://dx.doi.org/10.1145/2741948.2741976)
+    [doi:10.1145/2741948.2741976](https://dx.doi.org/10.1145/2741948.2741976)
 
 1.  Phillipa Gill, Navendu Jain, and Nachiappan Nagappan:
     “[Understanding Network Failures in Data Centers: Measurement, Analysis, and Implications](http://conferences.sigcomm.org/sigcomm/2011/papers/sigcomm/p350.pdf),” at
     *ACM SIGCOMM Conference*, August 2011.
-    [doi:10.1145/2018436.2018477](http://dx.doi.org/10.1145/2018436.2018477)
+    [doi:10.1145/2018436.2018477](https://dx.doi.org/10.1145/2018436.2018477)
 
 1.  Mark Imbriaco:
     “[Downtime Last Saturday](https://github.com/blog/1364-downtime-last-saturday),”
@@ -99,7 +99,7 @@ Chapter 8 References
 1.  Jerome H. Saltzer, David P. Reed, and David D. Clark:
     “[End-To-End Arguments in System Design](https://groups.csail.mit.edu/ana/Publications/PubPDFs/End-to-End%20Arguments%20in%20System%20Design.pdf),”
     *ACM Transactions on Computer Systems*, volume 2, number 4, pages 277–288, November 1984.
-    [doi:10.1145/357401.357402](http://dx.doi.org/10.1145/357401.357402)
+    [doi:10.1145/357401.357402](https://dx.doi.org/10.1145/357401.357402)
 
 1.  Matthew P. Grosvenor, Malte Schwarzkopf, Ionel Gog, et al.:
     “[Queues Don’t Matter When You Can JUMP Them!](https://www.usenix.org/system/files/conference/nsdi15/nsdi15-paper-grosvenor_update.pdf),” at *12th USENIX Symposium on Networked
@@ -108,12 +108,12 @@ Chapter 8 References
 1.  Guohui Wang and T. S. Eugene Ng:
       “[The Impact of Virtualization on Network Performance of Amazon EC2 Data Center](http://www.cs.rice.edu/~eugeneng/papers/INFOCOM10-ec2.pdf),” at *29th IEEE
       International Conference on Computer Communications* (INFOCOM), March 2010.
-      [doi:10.1109/INFCOM.2010.5461931](http://dx.doi.org/10.1109/INFCOM.2010.5461931)
+      [doi:10.1109/INFCOM.2010.5461931](https://dx.doi.org/10.1109/INFCOM.2010.5461931)
 
 1.  Van Jacobson:
       “[Congestion Avoidance and Control](http://www.cs.usask.ca/ftp/pub/discus/seminars2002-2003/p314-jacobson.pdf),” at *ACM Symposium on Communications Architectures and
       Protocols* (SIGCOMM), August 1988.
-      [doi:10.1145/52324.52356](http://dx.doi.org/10.1145/52324.52356)
+      [doi:10.1145/52324.52356](https://dx.doi.org/10.1145/52324.52356)
 
 1.  Brandon Philips:
     “[etcd: Distributed Locking and Service Discovery](https://www.youtube.com/watch?v=HJIjTTHWYnE),” at *Strange Loop*, September 2014.
@@ -144,7 +144,7 @@ Chapter 8 References
     “[End-to-End Congestion Control for InfiniBand](http://www.hpl.hp.com/techreports/2002/HPL-2002-359.pdf),” at *22nd Annual Joint Conference of the IEEE Computer and
     Communications Societies* (INFOCOM), April 2003. Also published by HP Laboratories Palo
     Alto, Tech Report HPL-2002-359.
-    [doi:10.1109/INFCOM.2003.1208949](http://dx.doi.org/10.1109/INFCOM.2003.1208949)
+    [doi:10.1109/INFCOM.2003.1208949](https://dx.doi.org/10.1109/INFCOM.2003.1208949)
 
 1.  Ulrich Windl, David Dalton, Marc Martinec, and Dale R. Worley:
     “[The NTP FAQ and HOWTO](http://www.ntp.org/ntpfaq/NTP-a-faq.htm),” *ntp.org*,
@@ -167,7 +167,7 @@ Chapter 8 References
 1.  M. Caporaloni and R. Ambrosini:
       “[How Closely Can a Personal Computer Clock Track the UTC Timescale Via the Internet?](https://iopscience.iop.org/0143-0807/23/4/103/),” *European Journal of
       Physics*, volume 23, number 4, pages L17–L21, June 2012.
-      [doi:10.1088/0143-0807/23/4/103](http://dx.doi.org/10.1088/0143-0807/23/4/103)
+      [doi:10.1088/0143-0807/23/4/103](https://dx.doi.org/10.1088/0143-0807/23/4/103)
 
 1.  Nelson Minar:
       “[A Survey of the NTP Network](http://alumni.media.mit.edu/~nelson/research/ntp-survey99/),”
@@ -178,7 +178,7 @@ Chapter 8 References
 
 1.  Poul-Henning Kamp:
       “[The One-Second War (What Time Will You Die?)](http://queue.acm.org/detail.cfm?id=1967009),” *ACM Queue*, volume 9, number 4, pages 44–48, April 2011.
-      [doi:10.1145/1966989.1967009](http://dx.doi.org/10.1145/1966989.1967009)
+      [doi:10.1145/1966989.1967009](https://dx.doi.org/10.1145/1966989.1967009)
 
 1.  Nelson Minar:
       “[Leap Second Crashes Half the Internet](http://www.somebits.com/weblog/tech/bad/leap-second-2012.html),” *somebits.com*, July 3, 2012.
@@ -192,7 +192,7 @@ Chapter 8 References
 1.  Darryl Veitch and Kanthaiah Vijayalayan:
       “[Network Timing and the 2015 Leap Second](https://tklab.feit.uts.edu.au/~darryl/Publications/LeapSecond_camera.pdf),” at *17th International Conference on Passive and Active
       Measurement* (PAM), April 2016.
-      [doi:10.1007/978-3-319-30505-9_29](http://dx.doi.org/10.1007/978-3-319-30505-9_29)
+      [doi:10.1007/978-3-319-30505-9_29](https://dx.doi.org/10.1007/978-3-319-30505-9_29)
 
 1.  “[Timekeeping in VMware Virtual Machines](https://www.vmware.com/content/dam/digitalmarketing/vmware/en/pdf/techpaper/Timekeeping-In-VirtualMachines.pdf),”
     Information Guide, VMware, Inc., December 2011.
@@ -217,7 +217,7 @@ Chapter 8 References
 1.  Leslie Lamport:
     “[Time, Clocks, and the Ordering of Events in a Distributed System](https://www.microsoft.com/en-us/research/publication/time-clocks-ordering-events-distributed-system/),”
     *Communications of the ACM*, volume 21, number 7, pages 558–565, July 1978.
-    [doi:10.1145/359545.359563](http://dx.doi.org/10.1145/359545.359563)
+    [doi:10.1145/359545.359563](https://dx.doi.org/10.1145/359545.359563)
 
 1.  Sandeep Kulkarni, Murat Demirbas, Deepak Madeppa, et al.:
     “[Logical Physical Clocks and Consistent Snapshots in Globally Distributed Databases](http://www.cse.buffalo.edu/tech-reports/2014-04.pdf),” State University of New York at
@@ -225,14 +225,14 @@ Chapter 8 References
 
 1.  Justin Sheehy:
     “[There Is No Now: Problems With Simultaneity in Distributed Systems](https://queue.acm.org/detail.cfm?id=2745385),” *ACM Queue*, volume 13, number 3, pages 36–41, March 2015.
-    [doi:10.1145/2733108](http://dx.doi.org/10.1145/2733108)
+    [doi:10.1145/2733108](https://dx.doi.org/10.1145/2733108)
 
 1.  Murat Demirbas:
     “[Spanner: Google's Globally-Distributed Database](http://muratbuffalo.blogspot.co.uk/2013/07/spanner-googles-globally-distributed_4.html),” *muratbuffalo.blogspot.co.uk*, July 4, 2013.
 
 1.  Dahlia Malkhi and Jean-Philippe Martin:
     “[Spanner's Concurrency Control](http://www.cs.cornell.edu/~ie53/publications/DC-col51-Sep13.pdf),” *ACM SIGACT News*, volume 44, number 3, pages 73–77, September 2013.
-    [doi:10.1145/2527748.2527767](http://dx.doi.org/10.1145/2527748.2527767)
+    [doi:10.1145/2527748.2527767](https://dx.doi.org/10.1145/2527748.2527767)
 
 1.  Manuel Bravo, Nuno Diegues, Jingna Zeng, et al.:
     “[On the Use of Clocks to Enforce Consistency in the Cloud](http://sites.computer.org/debull/A15mar/p18.pdf),” *IEEE Data Engineering Bulletin*,
@@ -244,7 +244,7 @@ Chapter 8 References
 1.  Cary G. Gray and David R. Cheriton:
     “[Leases: An Efficient Fault-Tolerant Mechanism for Distributed File Cache Consistency](https://web.archive.org/web/20230325205928/http://web.stanford.edu/class/cs240/readings/89-leases.pdf),” at
     *12th ACM Symposium on Operating Systems Principles* (SOSP), December 1989.
-    [doi:10.1145/74850.74870](http://dx.doi.org/10.1145/74850.74870)
+    [doi:10.1145/74850.74870](https://dx.doi.org/10.1145/74850.74870)
 
 1.  Todd Lipcon:
       “[Avoiding Full GCs in Apache HBase with MemStore-Local Allocation Buffers: Part 1](https://web.archive.org/web/20121101040711/http://blog.cloudera.com/blog/2011/02/avoiding-full-gcs-in-hbase-with-memstore-local-allocation-buffers-part-1/),”
@@ -297,7 +297,7 @@ Chapter 8 References
 1.  Leslie Lamport, Robert Shostak, and Marshall Pease:
     “[The Byzantine Generals Problem](https://www.microsoft.com/en-us/research/publication/byzantine-generals-problem/),”
     *ACM Transactions on Programming Languages and Systems* (TOPLAS), volume 4, number 3, pages 382–401, July 1982.
-    [doi:10.1145/357172.357176](http://dx.doi.org/10.1145/357172.357176)
+    [doi:10.1145/357172.357176](https://dx.doi.org/10.1145/357172.357176)
 
 1.  Jim N. Gray:
     “[Notes on Data Base Operating Systems](http://jimgray.azurewebsites.net/papers/dbos.pdf),” in *Operating Systems: An Advanced Course*, Lecture
@@ -333,23 +333,23 @@ Chapter 8 References
 1.  Jonathan Stone and Craig Partridge:
       “[When the CRC and TCP Checksum Disagree](https://web.archive.org/web/20220818235232/https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.27.7611&rep=rep1&type=pdf),” at *ACM Conference on Applications,
       Technologies, Architectures, and Protocols for Computer Communication* (SIGCOMM), August 2000.
-      [doi:10.1145/347059.347561](http://dx.doi.org/10.1145/347059.347561)
+      [doi:10.1145/347059.347561](https://dx.doi.org/10.1145/347059.347561)
 
 1.  Evan Jones:
       “[How Both TCP and Ethernet Checksums Fail](http://www.evanjones.ca/tcp-and-ethernet-checksums-fail.html),” *evanjones.ca*, October 5, 2015.
 
 1.  Cynthia Dwork, Nancy Lynch, and Larry Stockmeyer:
       “[Consensus in the Presence of Partial Synchrony](https://dl.acm.org/doi/10.1145/42282.42283),” *Journal of the ACM*, volume 35, number 2, pages 288–323,
-      April 1988. [doi:10.1145/42282.42283](http://dx.doi.org/10.1145/42282.42283)
+      April 1988. [doi:10.1145/42282.42283](https://dx.doi.org/10.1145/42282.42283)
 
 1.  Peter Bailis and Ali Ghodsi:
     “[Eventual Consistency Today: Limitations, Extensions, and Beyond](http://queue.acm.org/detail.cfm?id=2462076),” *ACM Queue*, volume 11, number 3, pages 55-63, March 2013.
-    [doi:10.1145/2460276.2462076](http://dx.doi.org/10.1145/2460276.2462076)
+    [doi:10.1145/2460276.2462076](https://dx.doi.org/10.1145/2460276.2462076)
 
 1.  Bowen Alpern and Fred B. Schneider:
     “[Defining Liveness](https://www.cs.cornell.edu/fbs/publications/DefLiveness.pdf),”
     *Information Processing Letters*, volume 21, number 4, pages 181–185, October 1985.
-    [doi:10.1016/0020-0190(85)90056-0](http://dx.doi.org/10.1016/0020-0190(85)90056-0)
+    [doi:10.1016/0020-0190(85)90056-0](https://dx.doi.org/10.1016/0020-0190(85)90056-0)
 
 1.  Flavio P. Junqueira:
     “[Dude, Where’s My Metadata?](https://web.archive.org/web/20230604215314/https://fpj.systems/2015/05/28/dude-wheres-my-metadata/),”
@@ -365,10 +365,9 @@ Chapter 8 References
     Leesatapornwongsa, et al.:
     “[Limplock: Understanding the Impact of Limpware on Scale-out Cloud Systems](http://ucare.cs.uchicago.edu/pdf/socc13-limplock.pdf),” at *4th ACM Symposium on Cloud Computing*
     (SoCC), October 2013.
-    [doi:10.1145/2523616.2523627](http://dx.doi.org/10.1145/2523616.2523627)
+    [doi:10.1145/2523616.2523627](https://dx.doi.org/10.1145/2523616.2523627)
 
 1.  Frank McSherry, Michael Isard, and Derek G. Murray:
     “[Scalability! But at What COST?](http://www.frankmcsherry.org/assets/COST.pdf),”
     at *15th USENIX Workshop on Hot Topics in Operating Systems* (HotOS),
     May 2015.
-

--- a/chapter-08-refs.md
+++ b/chapter-08-refs.md
@@ -6,7 +6,7 @@ Chapter 8 References
 
 1.  Mark Cavage:
     “[There’s Just No Getting Around It: You’re Building a Distributed System](http://queue.acm.org/detail.cfm?id=2482856),” *ACM Queue*, volume 11, number 4, pages 80-89, April 2013.
-    [doi:10.1145/2466486.2482856](https://dx.doi.org/10.1145/2466486.2482856)
+    [doi:10.1145/2466486.2482856](https://doi.org/10.1145/2466486.2482856)
 
 1.  Jay Kreps:
     “[Getting Real About Distributed System Reliability](http://blog.empathybox.com/post/19574936361/getting-real-about-distributed-system-reliability),” *blog.empathybox.com*, March 19, 2012.
@@ -28,7 +28,7 @@ Chapter 8 References
     “[The Datacenter as a Computer: An Introduction to the Design of Warehouse-Scale Machines, Second Edition](https://web.archive.org/web/20140404113735/http://www.morganclaypool.com/doi/abs/10.2200/S00516ED2V01Y201306CAC024),”
     *Synthesis Lectures on Computer Architecture*, volume 8, number 3,
     Morgan & Claypool Publishers, July 2013.
-    [doi:10.2200/S00516ED2V01Y201306CAC024](https://dx.doi.org/10.2200/S00516ED2V01Y201306CAC024),
+    [doi:10.2200/S00516ED2V01Y201306CAC024](https://doi.org/10.2200/S00516ED2V01Y201306CAC024),
     ISBN: 978-1-627-05010-4
 
 1.  David Fiala, Frank Mueller, Christian Engelmann, et al.:
@@ -39,7 +39,7 @@ Chapter 8 References
 1.  Arjun Singh, Joon Ong, Amit Agarwal, et al.:
       “[Jupiter Rising: A Decade of Clos Topologies and Centralized Control in Google’s Datacenter Network](http://conferences.sigcomm.org/sigcomm/2015/pdf/papers/p183.pdf),” at
       *Annual Conference of the ACM Special Interest Group on Data Communication* (SIGCOMM), August 2015.
-      [doi:10.1145/2785956.2787508](https://dx.doi.org/10.1145/2785956.2787508)
+      [doi:10.1145/2785956.2787508](https://doi.org/10.1145/2785956.2787508)
 
 1.  Glenn K. Lockwood:
       “[Hadoop's Uncomfortable Fit in HPC](http://glennklockwood.blogspot.co.uk/2014/05/hadoops-uncomfortable-fit-in-hpc.html),” *glennklockwood.blogspot.co.uk*, May 16, 2014.
@@ -60,17 +60,17 @@ Chapter 8 References
 1.  Peter Bailis and Kyle Kingsbury:
     “[The Network Is Reliable](https://queue.acm.org/detail.cfm?id=2655736),”
     *ACM Queue*, volume 12, number 7, pages 48-55, July 2014.
-    [doi:10.1145/2639988.2639988](https://dx.doi.org/10.1145/2639988.2639988)
+    [doi:10.1145/2639988.2639988](https://doi.org/10.1145/2639988.2639988)
 
 1.  Joshua B. Leners, Trinabh Gupta, Marcos K. Aguilera, and Michael Walfish:
     “[Taming Uncertainty in Distributed Systems with Help from the Network](http://www.cs.nyu.edu/~mwalfish/papers/albatross-eurosys15.pdf),” at *10th European Conference on
     Computer Systems* (EuroSys), April 2015.
-    [doi:10.1145/2741948.2741976](https://dx.doi.org/10.1145/2741948.2741976)
+    [doi:10.1145/2741948.2741976](https://doi.org/10.1145/2741948.2741976)
 
 1.  Phillipa Gill, Navendu Jain, and Nachiappan Nagappan:
     “[Understanding Network Failures in Data Centers: Measurement, Analysis, and Implications](http://conferences.sigcomm.org/sigcomm/2011/papers/sigcomm/p350.pdf),” at
     *ACM SIGCOMM Conference*, August 2011.
-    [doi:10.1145/2018436.2018477](https://dx.doi.org/10.1145/2018436.2018477)
+    [doi:10.1145/2018436.2018477](https://doi.org/10.1145/2018436.2018477)
 
 1.  Mark Imbriaco:
     “[Downtime Last Saturday](https://github.com/blog/1364-downtime-last-saturday),”
@@ -99,7 +99,7 @@ Chapter 8 References
 1.  Jerome H. Saltzer, David P. Reed, and David D. Clark:
     “[End-To-End Arguments in System Design](https://groups.csail.mit.edu/ana/Publications/PubPDFs/End-to-End%20Arguments%20in%20System%20Design.pdf),”
     *ACM Transactions on Computer Systems*, volume 2, number 4, pages 277–288, November 1984.
-    [doi:10.1145/357401.357402](https://dx.doi.org/10.1145/357401.357402)
+    [doi:10.1145/357401.357402](https://doi.org/10.1145/357401.357402)
 
 1.  Matthew P. Grosvenor, Malte Schwarzkopf, Ionel Gog, et al.:
     “[Queues Don’t Matter When You Can JUMP Them!](https://www.usenix.org/system/files/conference/nsdi15/nsdi15-paper-grosvenor_update.pdf),” at *12th USENIX Symposium on Networked
@@ -108,12 +108,12 @@ Chapter 8 References
 1.  Guohui Wang and T. S. Eugene Ng:
       “[The Impact of Virtualization on Network Performance of Amazon EC2 Data Center](http://www.cs.rice.edu/~eugeneng/papers/INFOCOM10-ec2.pdf),” at *29th IEEE
       International Conference on Computer Communications* (INFOCOM), March 2010.
-      [doi:10.1109/INFCOM.2010.5461931](https://dx.doi.org/10.1109/INFCOM.2010.5461931)
+      [doi:10.1109/INFCOM.2010.5461931](https://doi.org/10.1109/INFCOM.2010.5461931)
 
 1.  Van Jacobson:
       “[Congestion Avoidance and Control](http://www.cs.usask.ca/ftp/pub/discus/seminars2002-2003/p314-jacobson.pdf),” at *ACM Symposium on Communications Architectures and
       Protocols* (SIGCOMM), August 1988.
-      [doi:10.1145/52324.52356](https://dx.doi.org/10.1145/52324.52356)
+      [doi:10.1145/52324.52356](https://doi.org/10.1145/52324.52356)
 
 1.  Brandon Philips:
     “[etcd: Distributed Locking and Service Discovery](https://www.youtube.com/watch?v=HJIjTTHWYnE),” at *Strange Loop*, September 2014.
@@ -144,7 +144,7 @@ Chapter 8 References
     “[End-to-End Congestion Control for InfiniBand](http://www.hpl.hp.com/techreports/2002/HPL-2002-359.pdf),” at *22nd Annual Joint Conference of the IEEE Computer and
     Communications Societies* (INFOCOM), April 2003. Also published by HP Laboratories Palo
     Alto, Tech Report HPL-2002-359.
-    [doi:10.1109/INFCOM.2003.1208949](https://dx.doi.org/10.1109/INFCOM.2003.1208949)
+    [doi:10.1109/INFCOM.2003.1208949](https://doi.org/10.1109/INFCOM.2003.1208949)
 
 1.  Ulrich Windl, David Dalton, Marc Martinec, and Dale R. Worley:
     “[The NTP FAQ and HOWTO](http://www.ntp.org/ntpfaq/NTP-a-faq.htm),” *ntp.org*,
@@ -167,7 +167,7 @@ Chapter 8 References
 1.  M. Caporaloni and R. Ambrosini:
       “[How Closely Can a Personal Computer Clock Track the UTC Timescale Via the Internet?](https://iopscience.iop.org/0143-0807/23/4/103/),” *European Journal of
       Physics*, volume 23, number 4, pages L17–L21, June 2012.
-      [doi:10.1088/0143-0807/23/4/103](https://dx.doi.org/10.1088/0143-0807/23/4/103)
+      [doi:10.1088/0143-0807/23/4/103](https://doi.org/10.1088/0143-0807/23/4/103)
 
 1.  Nelson Minar:
       “[A Survey of the NTP Network](http://alumni.media.mit.edu/~nelson/research/ntp-survey99/),”
@@ -178,7 +178,7 @@ Chapter 8 References
 
 1.  Poul-Henning Kamp:
       “[The One-Second War (What Time Will You Die?)](http://queue.acm.org/detail.cfm?id=1967009),” *ACM Queue*, volume 9, number 4, pages 44–48, April 2011.
-      [doi:10.1145/1966989.1967009](https://dx.doi.org/10.1145/1966989.1967009)
+      [doi:10.1145/1966989.1967009](https://doi.org/10.1145/1966989.1967009)
 
 1.  Nelson Minar:
       “[Leap Second Crashes Half the Internet](http://www.somebits.com/weblog/tech/bad/leap-second-2012.html),” *somebits.com*, July 3, 2012.
@@ -192,7 +192,7 @@ Chapter 8 References
 1.  Darryl Veitch and Kanthaiah Vijayalayan:
       “[Network Timing and the 2015 Leap Second](https://tklab.feit.uts.edu.au/~darryl/Publications/LeapSecond_camera.pdf),” at *17th International Conference on Passive and Active
       Measurement* (PAM), April 2016.
-      [doi:10.1007/978-3-319-30505-9_29](https://dx.doi.org/10.1007/978-3-319-30505-9_29)
+      [doi:10.1007/978-3-319-30505-9_29](https://doi.org/10.1007/978-3-319-30505-9_29)
 
 1.  “[Timekeeping in VMware Virtual Machines](https://www.vmware.com/content/dam/digitalmarketing/vmware/en/pdf/techpaper/Timekeeping-In-VirtualMachines.pdf),”
     Information Guide, VMware, Inc., December 2011.
@@ -217,7 +217,7 @@ Chapter 8 References
 1.  Leslie Lamport:
     “[Time, Clocks, and the Ordering of Events in a Distributed System](https://www.microsoft.com/en-us/research/publication/time-clocks-ordering-events-distributed-system/),”
     *Communications of the ACM*, volume 21, number 7, pages 558–565, July 1978.
-    [doi:10.1145/359545.359563](https://dx.doi.org/10.1145/359545.359563)
+    [doi:10.1145/359545.359563](https://doi.org/10.1145/359545.359563)
 
 1.  Sandeep Kulkarni, Murat Demirbas, Deepak Madeppa, et al.:
     “[Logical Physical Clocks and Consistent Snapshots in Globally Distributed Databases](http://www.cse.buffalo.edu/tech-reports/2014-04.pdf),” State University of New York at
@@ -225,14 +225,14 @@ Chapter 8 References
 
 1.  Justin Sheehy:
     “[There Is No Now: Problems With Simultaneity in Distributed Systems](https://queue.acm.org/detail.cfm?id=2745385),” *ACM Queue*, volume 13, number 3, pages 36–41, March 2015.
-    [doi:10.1145/2733108](https://dx.doi.org/10.1145/2733108)
+    [doi:10.1145/2733108](https://doi.org/10.1145/2733108)
 
 1.  Murat Demirbas:
     “[Spanner: Google's Globally-Distributed Database](http://muratbuffalo.blogspot.co.uk/2013/07/spanner-googles-globally-distributed_4.html),” *muratbuffalo.blogspot.co.uk*, July 4, 2013.
 
 1.  Dahlia Malkhi and Jean-Philippe Martin:
     “[Spanner's Concurrency Control](http://www.cs.cornell.edu/~ie53/publications/DC-col51-Sep13.pdf),” *ACM SIGACT News*, volume 44, number 3, pages 73–77, September 2013.
-    [doi:10.1145/2527748.2527767](https://dx.doi.org/10.1145/2527748.2527767)
+    [doi:10.1145/2527748.2527767](https://doi.org/10.1145/2527748.2527767)
 
 1.  Manuel Bravo, Nuno Diegues, Jingna Zeng, et al.:
     “[On the Use of Clocks to Enforce Consistency in the Cloud](http://sites.computer.org/debull/A15mar/p18.pdf),” *IEEE Data Engineering Bulletin*,
@@ -244,7 +244,7 @@ Chapter 8 References
 1.  Cary G. Gray and David R. Cheriton:
     “[Leases: An Efficient Fault-Tolerant Mechanism for Distributed File Cache Consistency](https://web.archive.org/web/20230325205928/http://web.stanford.edu/class/cs240/readings/89-leases.pdf),” at
     *12th ACM Symposium on Operating Systems Principles* (SOSP), December 1989.
-    [doi:10.1145/74850.74870](https://dx.doi.org/10.1145/74850.74870)
+    [doi:10.1145/74850.74870](https://doi.org/10.1145/74850.74870)
 
 1.  Todd Lipcon:
       “[Avoiding Full GCs in Apache HBase with MemStore-Local Allocation Buffers: Part 1](https://web.archive.org/web/20121101040711/http://blog.cloudera.com/blog/2011/02/avoiding-full-gcs-in-hbase-with-memstore-local-allocation-buffers-part-1/),”
@@ -297,7 +297,7 @@ Chapter 8 References
 1.  Leslie Lamport, Robert Shostak, and Marshall Pease:
     “[The Byzantine Generals Problem](https://www.microsoft.com/en-us/research/publication/byzantine-generals-problem/),”
     *ACM Transactions on Programming Languages and Systems* (TOPLAS), volume 4, number 3, pages 382–401, July 1982.
-    [doi:10.1145/357172.357176](https://dx.doi.org/10.1145/357172.357176)
+    [doi:10.1145/357172.357176](https://doi.org/10.1145/357172.357176)
 
 1.  Jim N. Gray:
     “[Notes on Data Base Operating Systems](http://jimgray.azurewebsites.net/papers/dbos.pdf),” in *Operating Systems: An Advanced Course*, Lecture
@@ -333,23 +333,23 @@ Chapter 8 References
 1.  Jonathan Stone and Craig Partridge:
       “[When the CRC and TCP Checksum Disagree](https://web.archive.org/web/20220818235232/https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.27.7611&rep=rep1&type=pdf),” at *ACM Conference on Applications,
       Technologies, Architectures, and Protocols for Computer Communication* (SIGCOMM), August 2000.
-      [doi:10.1145/347059.347561](https://dx.doi.org/10.1145/347059.347561)
+      [doi:10.1145/347059.347561](https://doi.org/10.1145/347059.347561)
 
 1.  Evan Jones:
       “[How Both TCP and Ethernet Checksums Fail](http://www.evanjones.ca/tcp-and-ethernet-checksums-fail.html),” *evanjones.ca*, October 5, 2015.
 
 1.  Cynthia Dwork, Nancy Lynch, and Larry Stockmeyer:
       “[Consensus in the Presence of Partial Synchrony](https://dl.acm.org/doi/10.1145/42282.42283),” *Journal of the ACM*, volume 35, number 2, pages 288–323,
-      April 1988. [doi:10.1145/42282.42283](https://dx.doi.org/10.1145/42282.42283)
+      April 1988. [doi:10.1145/42282.42283](https://doi.org/10.1145/42282.42283)
 
 1.  Peter Bailis and Ali Ghodsi:
     “[Eventual Consistency Today: Limitations, Extensions, and Beyond](http://queue.acm.org/detail.cfm?id=2462076),” *ACM Queue*, volume 11, number 3, pages 55-63, March 2013.
-    [doi:10.1145/2460276.2462076](https://dx.doi.org/10.1145/2460276.2462076)
+    [doi:10.1145/2460276.2462076](https://doi.org/10.1145/2460276.2462076)
 
 1.  Bowen Alpern and Fred B. Schneider:
     “[Defining Liveness](https://www.cs.cornell.edu/fbs/publications/DefLiveness.pdf),”
     *Information Processing Letters*, volume 21, number 4, pages 181–185, October 1985.
-    [doi:10.1016/0020-0190(85)90056-0](https://dx.doi.org/10.1016/0020-0190(85)90056-0)
+    [doi:10.1016/0020-0190(85)90056-0](https://doi.org/10.1016/0020-0190(85)90056-0)
 
 1.  Flavio P. Junqueira:
     “[Dude, Where’s My Metadata?](https://web.archive.org/web/20230604215314/https://fpj.systems/2015/05/28/dude-wheres-my-metadata/),”
@@ -365,7 +365,7 @@ Chapter 8 References
     Leesatapornwongsa, et al.:
     “[Limplock: Understanding the Impact of Limpware on Scale-out Cloud Systems](http://ucare.cs.uchicago.edu/pdf/socc13-limplock.pdf),” at *4th ACM Symposium on Cloud Computing*
     (SoCC), October 2013.
-    [doi:10.1145/2523616.2523627](https://dx.doi.org/10.1145/2523616.2523627)
+    [doi:10.1145/2523616.2523627](https://doi.org/10.1145/2523616.2523627)
 
 1.  Frank McSherry, Michael Isard, and Derek G. Murray:
     “[Scalability! But at What COST?](http://www.frankmcsherry.org/assets/COST.pdf),”

--- a/chapter-09-refs.md
+++ b/chapter-09-refs.md
@@ -6,7 +6,7 @@ Chapter 9 References
 
 1.  Peter Bailis and Ali Ghodsi:
     “[Eventual Consistency Today: Limitations, Extensions, and Beyond](http://queue.acm.org/detail.cfm?id=2462076),” *ACM Queue*, volume 11, number 3, pages 55-63, March 2013.
-    [doi:10.1145/2460276.2462076](https://dx.doi.org/10.1145/2460276.2462076)
+    [doi:10.1145/2460276.2462076](https://doi.org/10.1145/2460276.2462076)
 
 1.  Prince Mahajan, Lorenzo Alvisi, and Mike Dahlin:
     “[Consistency, Availability, and Convergence](http://apps.cs.utexas.edu/tech_reports/reports/tr/TR-2036.pdf),” University of Texas at Austin, Department of Computer
@@ -25,12 +25,12 @@ Chapter 9 References
 1.  Maurice P. Herlihy and Jeannette M. Wing:
     “[Linearizability: A Correctness Condition for Concurrent Objects](http://cs.brown.edu/~mph/HerlihyW90/p463-herlihy.pdf),” *ACM Transactions on Programming
     Languages and Systems* (TOPLAS), volume 12, number 3, pages 463–492, July 1990.
-    [doi:10.1145/78969.78972](https://dx.doi.org/10.1145/78969.78972)
+    [doi:10.1145/78969.78972](https://doi.org/10.1145/78969.78972)
 
 1.  Leslie Lamport:
     “[On interprocess communication](https://www.microsoft.com/en-us/research/publication/interprocess-communication-part-basic-formalism-part-ii-algorithms/),”
     *Distributed Computing*, volume 1, number 2, pages 77–101, June 1986.
-    [doi:10.1007/BF01786228](https://dx.doi.org/10.1007/BF01786228)
+    [doi:10.1007/BF01786228](https://doi.org/10.1007/BF01786228)
 
 1.  David K. Gifford:
     “[Information Storage in a Decentralized Computer System](http://www.mirrorservice.org/sites/www.bitsavers.org/pdf/xerox/parc/techReports/CSL-81-8_Information_Storage_in_a_Decentralized_Computer_System.pdf),” Xerox Palo Alto Research Centers, CSL-81-8, June 1981.
@@ -77,7 +77,7 @@ Chapter 9 References
 1.  Flavio P. Junqueira, Benjamin C. Reed, and Marco Serafini:
       “[Zab: High-Performance Broadcast for Primary-Backup Systems](https://web.archive.org/web/20220419064903/https://marcoserafini.github.io/papers/zab.pdf),”
       at *41st IEEE International Conference on Dependable Systems and Networks* (DSN), June 2011.
-      [doi:10.1109/DSN.2011.5958223](https://dx.doi.org/10.1109/DSN.2011.5958223)
+      [doi:10.1109/DSN.2011.5958223](https://doi.org/10.1109/DSN.2011.5958223)
 
 1.  Diego Ongaro and John K. Ousterhout:
       “[In Search of an Understandable Consensus Algorithm](https://www.usenix.org/system/files/conference/atc14/atc14-paper-ongaro.pdf),”
@@ -86,17 +86,17 @@ Chapter 9 References
 1.  Hagit Attiya, Amotz Bar-Noy, and Danny Dolev:
     “[Sharing Memory Robustly in Message-Passing Systems](http://www.cse.huji.ac.il/course/2004/dist/p124-attiya.pdf),”
     *Journal of the ACM*, volume 42, number 1, pages 124–142, January 1995.
-    [doi:10.1145/200836.200869](https://dx.doi.org/10.1145/200836.200869)
+    [doi:10.1145/200836.200869](https://doi.org/10.1145/200836.200869)
 
 1.  Nancy Lynch and Alex Shvartsman:
     “[Robust Emulation of Shared Memory Using Dynamic Quorum-Acknowledged Broadcasts](http://groups.csail.mit.edu/tds/papers/Lynch/FTCS97.pdf),” at *27th Annual International Symposium on
     Fault-Tolerant Computing* (FTCS), June 1997.
-    [doi:10.1109/FTCS.1997.614100](https://dx.doi.org/10.1109/FTCS.1997.614100)
+    [doi:10.1109/FTCS.1997.614100](https://doi.org/10.1109/FTCS.1997.614100)
 
 1.  Christian Cachin, Rachid Guerraoui, and Luís Rodrigues:
     [*Introduction to Reliable and Secure Distributed Programming*](http://www.distributedprogramming.net/),
     2nd edition. Springer, 2011. ISBN: 978-3-642-15259-7,
-    [doi:10.1007/978-3-642-15260-3](https://dx.doi.org/10.1007/978-3-642-15260-3)
+    [doi:10.1007/978-3-642-15260-3](https://doi.org/10.1007/978-3-642-15260-3)
 
 1.  Sam Elliott, Mark Allen, and Martin Kleppmann:
     [personal communication](https://web.archive.org/web/20230620021338/https://twitter.com/lenary/status/654761711933648896),
@@ -109,29 +109,29 @@ Chapter 9 References
     “[Wait-Free Synchronization](https://cs.brown.edu/~mph/Herlihy91/p124-herlihy.pdf),”
     *ACM Transactions on Programming Languages and Systems* (TOPLAS), volume 13, number 1,
     pages 124–149, January 1991.
-    [doi:10.1145/114005.102808](https://dx.doi.org/10.1145/114005.102808)
+    [doi:10.1145/114005.102808](https://doi.org/10.1145/114005.102808)
 
 1.  Armando Fox and Eric A. Brewer:
     “[Harvest, Yield, and Scalable Tolerant Systems](http://radlab.cs.berkeley.edu/people/fox/static/pubs/pdf/c18.pdf),” at *7th Workshop on Hot Topics in Operating
     Systems* (HotOS), March 1999.
-    [doi:10.1109/HOTOS.1999.798396](https://dx.doi.org/10.1109/HOTOS.1999.798396)
+    [doi:10.1109/HOTOS.1999.798396](https://doi.org/10.1109/HOTOS.1999.798396)
 
 1.  Seth Gilbert and Nancy Lynch:
     “[Brewer’s Conjecture and the Feasibility of Consistent, Available, Partition-Tolerant Web Services](http://www.comp.nus.edu.sg/~gilbert/pubs/BrewersConjecture-SigAct.pdf),”
     *ACM SIGACT News*, volume 33, number 2, pages 51–59, June 2002.
-    [doi:10.1145/564585.564601](https://dx.doi.org/10.1145/564585.564601)
+    [doi:10.1145/564585.564601](https://doi.org/10.1145/564585.564601)
 
 1.  Seth Gilbert and Nancy Lynch:
     “[Perspectives on the CAP Theorem](http://groups.csail.mit.edu/tds/papers/Gilbert/Brewer2.pdf),” *IEEE Computer Magazine*, volume 45, number 2, pages 30–36, February 2012.
-    [doi:10.1109/MC.2011.389](https://dx.doi.org/10.1109/MC.2011.389)
+    [doi:10.1109/MC.2011.389](https://doi.org/10.1109/MC.2011.389)
 
 1.  Eric A. Brewer:
     “[CAP Twelve Years Later: How the 'Rules' Have Changed](https://web.archive.org/web/20221222092656/http://cs609.cs.ua.edu/CAP12.pdf),” *IEEE Computer Magazine*, volume 45, number 2, pages 23–29, February 2012.
-    [doi:10.1109/MC.2012.37](https://dx.doi.org/10.1109/MC.2012.37)
+    [doi:10.1109/MC.2012.37](https://doi.org/10.1109/MC.2012.37)
 
 1.  Susan B. Davidson, Hector Garcia-Molina, and Dale Skeen:
     “[Consistency in Partitioned Networks](http://delab.csd.auth.gr/~dimitris/courses/mpc_fall05/papers/invalidation/acm_csur85_partitioned_network_consistency.pdf),” *ACM Computing Surveys*, volume 17, number 3, pages 341–370, September 1985.
-    [doi:10.1145/5505.5508](https://dx.doi.org/10.1145/5505.5508)
+    [doi:10.1145/5505.5508](https://doi.org/10.1145/5505.5508)
 
 1.  Paul R. Johnson and Robert H. Thomas:
     “[RFC 677: The Maintenance of Duplicate Databases](https://tools.ietf.org/html/rfc677),” Network Working Group, January 27, 1975.
@@ -142,7 +142,7 @@ Chapter 9 References
 1.  Michael J. Fischer and Alan Michael:
     “[Sacrificing Serializability to Attain High Availability of Data in an Unreliable Network](http://www.cs.ucsb.edu/~agrawal/spring2011/ugrad/p70-fischer.pdf),” at
     *1st ACM Symposium on Principles of Database Systems* (PODS), March 1982.
-    [doi:10.1145/588111.588124](https://dx.doi.org/10.1145/588111.588124)
+    [doi:10.1145/588111.588124](https://doi.org/10.1145/588111.588124)
 
 1.  Eric A. Brewer:
     “[NoSQL: Past, Present, Future](http://www.infoq.com/presentations/NoSQL-History),”
@@ -162,18 +162,18 @@ Chapter 9 References
 1.  Nancy A. Lynch:
     “[A Hundred Impossibility Proofs for Distributed Computing](http://groups.csail.mit.edu/tds/papers/Lynch/podc89.pdf),” at *8th ACM Symposium on Principles of Distributed
     Computing* (PODC), August 1989.
-    [doi:10.1145/72981.72982](https://dx.doi.org/10.1145/72981.72982)
+    [doi:10.1145/72981.72982](https://doi.org/10.1145/72981.72982)
 
 1.  Hagit Attiya, Faith Ellen, and Adam Morrison:
     “[Limitations of Highly-Available Eventually-Consistent Data Stores](https://www.cs.tau.ac.il/~mad/publications/podc2015-replds.pdf),”
     at *ACM Symposium on Principles of Distributed Computing* (PODC), July 2015.
-    [doi:10.1145/2767386.2767419](https://dx.doi.org/10.1145/2767386.2767419)
+    [doi:10.1145/2767386.2767419](https://doi.org/10.1145/2767386.2767419)
 
 1.  Peter Sewell, Susmit Sarkar,
     Scott Owens, et al.:
     “[x86-TSO: A Rigorous and Usable Programmer's Model for x86 Multiprocessors](http://www.cl.cam.ac.uk/~pes20/weakmemory/cacm.pdf),” *Communications of the ACM*,
     volume 53, number 7, pages 89–97, July 2010.
-    [doi:10.1145/1785414.1785443](https://dx.doi.org/10.1145/1785414.1785443)
+    [doi:10.1145/1785414.1785443](https://doi.org/10.1145/1785414.1785443)
 
 1.  Martin Thompson:
     “[Memory Barriers/Fences](http://mechanical-sympathy.blogspot.co.uk/2011/07/memory-barriersfences.html),” *mechanical-sympathy.blogspot.co.uk*, July 24, 2011.
@@ -184,17 +184,17 @@ Chapter 9 References
 1.  Daniel J. Abadi:
     “[Consistency Tradeoffs in Modern Distributed Database System Design](http://cs-www.cs.yale.edu/homes/dna/papers/abadi-pacelc.pdf),” *IEEE Computer Magazine*,
     volume 45, number 2, pages 37–42, February 2012.
-    [doi:10.1109/MC.2012.33](https://dx.doi.org/10.1109/MC.2012.33)
+    [doi:10.1109/MC.2012.33](https://doi.org/10.1109/MC.2012.33)
 
 1.  Hagit Attiya and Jennifer L. Welch:
     “[Sequential Consistency Versus Linearizability](http://courses.csail.mit.edu/6.852/01/papers/p91-attiya.pdf),” *ACM Transactions on Computer Systems* (TOCS),
     volume 12, number 2, pages 91–122, May 1994.
-    [doi:10.1145/176575.176576](https://dx.doi.org/10.1145/176575.176576)
+    [doi:10.1145/176575.176576](https://doi.org/10.1145/176575.176576)
 
 1.  Mustaque Ahamad, Gil Neiger, James E. Burns, et al.:
       “[Causal   Memory: Definitions, Implementation, and Programming](http://www-i2.informatik.rwth-aachen.de/i2/fileadmin/user_upload/documents/Seminar_MCMM11/Causal_memory_1996.pdf),” *Distributed
       Computing*, volume 9, number 1, pages 37–49, March 1995.
-      [doi:10.1007/BF01784241](https://dx.doi.org/10.1007/BF01784241)
+      [doi:10.1007/BF01784241](https://doi.org/10.1007/BF01784241)
 
 1.  Wyatt Lloyd, Michael J. Freedman,
     Michael Kaminsky, and David G. Andersen:
@@ -220,7 +220,7 @@ Chapter 9 References
     Carlos Baquero, and Victor Fonte:
     “[Concise Server-Wide Causality Management for Eventually Consistent Data Stores](https://web.archive.org/web/20220810205439/http://haslab.uminho.pt/tome/files/global_logical_clocks.pdf),” at *15th IFIP International
     Conference on Distributed Applications and Interoperable Systems* (DAIS), June 2015.
-    [doi:10.1007/978-3-319-19129-4_6](https://dx.doi.org/10.1007/978-3-319-19129-4_6)
+    [doi:10.1007/978-3-319-19129-4_6](https://doi.org/10.1007/978-3-319-19129-4_6)
 
 1.  Rob Conery:
       “[A Better ID Generator for PostgreSQL](https://web.archive.org/web/20220118044729/http://rob.conery.io/2014/05/29/a-better-id-generator-for-postgresql/),” *rob.conery.io*, May 29, 2014.
@@ -228,17 +228,17 @@ Chapter 9 References
 1.  Leslie Lamport:
     “[Time, Clocks, and the Ordering of Events in a Distributed System](https://www.microsoft.com/en-us/research/publication/time-clocks-ordering-events-distributed-system/),”
     *Communications of the ACM*, volume 21, number 7, pages 558–565, July 1978.
-    [doi:10.1145/359545.359563](https://dx.doi.org/10.1145/359545.359563)
+    [doi:10.1145/359545.359563](https://doi.org/10.1145/359545.359563)
 
 1.  Xavier Défago, André Schiper, and Péter Urbán:
     “[Total Order Broadcast and Multicast Algorithms: Taxonomy and Survey](https://dspace.jaist.ac.jp/dspace/bitstream/10119/4883/1/defago_et_al.pdf),” *ACM Computing
     Surveys*, volume 36, number 4, pages 372–421, December 2004.
-    [doi:10.1145/1041680.1041682](https://dx.doi.org/10.1145/1041680.1041682)
+    [doi:10.1145/1041680.1041682](https://doi.org/10.1145/1041680.1041682)
 
 1.  Hagit Attiya and Jennifer Welch: *Distributed
     Computing: Fundamentals, Simulations and Advanced Topics*, 2nd edition.
     John Wiley & Sons, 2004. ISBN: 978-0-471-45324-6,
-    [doi:10.1002/0471478210](https://dx.doi.org/10.1002/0471478210)
+    [doi:10.1002/0471478210](https://doi.org/10.1002/0471478210)
 
 1.  Mahesh
     Balakrishnan, Dahlia Malkhi, Vijayan Prabhakaran, et al.:
@@ -256,7 +256,7 @@ Chapter 9 References
 1.  Mahesh Balakrishnan, Dahlia Malkhi, Ted Wobber, et al.:
     “[Tango: Distributed Data Structures over a Shared Log](https://www.microsoft.com/en-us/research/publication/tango-distributed-data-structures-over-a-shared-log/),”
     at *24th ACM Symposium on Operating Systems Principles* (SOSP), November 2013.
-    [doi:10.1145/2517349.2522732](https://dx.doi.org/10.1145/2517349.2522732)
+    [doi:10.1145/2517349.2522732](https://doi.org/10.1145/2517349.2522732)
 
 1.  Robbert van Renesse and Fred B. Schneider:
     “[Chain Replication for Supporting High Throughput and Availability](http://static.usenix.org/legacy/events/osdi04/tech/full_papers/renesse/renesse.pdf),” at *6th USENIX
@@ -265,7 +265,7 @@ Chapter 9 References
 1.  Leslie Lamport:
     “[How to Make a Multiprocessor Computer That Correctly Executes Multiprocess Programs](https://lamport.azurewebsites.net/pubs/multi.pdf),”
     *IEEE Transactions on Computers*, volume 28, number 9, pages 690–691, September 1979.
-    [doi:10.1109/TC.1979.1675439](https://dx.doi.org/10.1109/TC.1979.1675439)
+    [doi:10.1109/TC.1979.1675439](https://doi.org/10.1109/TC.1979.1675439)
 
 1.  Enis Söztutar, Devaraj Das, and Carter Shanklin:
     “[Apache HBase High Availability at the Next Level](https://web.archive.org/web/20160405122821/http://hortonworks.com/blog/apache-hbase-high-availability-next-level/),”
@@ -274,16 +274,16 @@ Chapter 9 References
 1.  Brian F Cooper, Raghu Ramakrishnan, Utkarsh Srivastava, et al.:
     “[PNUTS: Yahoo!’s Hosted Data Serving Platform](http://www.mpi-sws.org/~druschel/courses/ds/papers/cooper-pnuts.pdf),” at *34th International Conference on Very Large Data
     Bases* (VLDB), August 2008.
-    [doi:10.14778/1454159.1454167](https://dx.doi.org/10.14778/1454159.1454167)
+    [doi:10.14778/1454159.1454167](https://doi.org/10.14778/1454159.1454167)
 
 1.  Tushar Deepak Chandra and Sam Toueg:
     “[Unreliable Failure Detectors for Reliable Distributed Systems](http://courses.csail.mit.edu/6.852/08/papers/CT96-JACM.pdf),” *Journal of the ACM*,
     volume 43, number 2, pages 225–267, March 1996.
-    [doi:10.1145/226643.226647](https://dx.doi.org/10.1145/226643.226647)
+    [doi:10.1145/226643.226647](https://doi.org/10.1145/226643.226647)
 
 1.  Michael J. Fischer, Nancy Lynch, and Michael S. Paterson:
     “[Impossibility of Distributed Consensus with One Faulty Process](https://groups.csail.mit.edu/tds/papers/Lynch/jacm85.pdf),” *Journal of the ACM*, volume 32, number 2, pages 374–382, April 1985.
-    [doi:10.1145/3149.214121](https://dx.doi.org/10.1145/3149.214121)
+    [doi:10.1145/3149.214121](https://doi.org/10.1145/3149.214121)
 
 1.  Michael Ben-Or: “Another Advantage of Free
     Choice: Completely Asynchronous Agreement Protocols,” at *2nd ACM Symposium on Principles of
@@ -293,12 +293,12 @@ Chapter 9 References
 1.  Jim N. Gray and Leslie Lamport:
     “[Consensus on Transaction Commit](http://db.cs.berkeley.edu/cs286/papers/paxoscommit-tods2006.pdf),” *ACM Transactions on Database Systems* (TODS), volume 31,
     number 1, pages 133–160, March 2006.
-    [doi:10.1145/1132863.1132867](https://dx.doi.org/10.1145/1132863.1132867)
+    [doi:10.1145/1132863.1132867](https://doi.org/10.1145/1132863.1132867)
 
 1.  Rachid Guerraoui:
     “[Revisiting the Relationship Between Non-Blocking Atomic Commitment and Consensus](https://citeseerx.ist.psu.edu/pdf/5d06489503b6f791aa56d2d7942359c2592e44b0),”
     at *9th International Workshop on Distributed Algorithms* (WDAG), September 1995.
-    [doi:10.1007/BFb0022140](https://dx.doi.org/10.1007/BFb0022140)
+    [doi:10.1007/BFb0022140](https://doi.org/10.1007/BFb0022140)
 
 1.  Thanumalayan Sankaranarayana Pillai, Vijay Chidambaram,
     Ramnatthan Alagappan, et al.: “[All File Systems Are Not Created Equal: On the Complexity of Crafting Crash-Consistent Applications](http://research.cs.wisc.edu/wind/Publications/alice-osdi14.pdf),”
@@ -312,12 +312,12 @@ Chapter 9 References
 1.  Hector Garcia-Molina and Kenneth Salem:
     “[Sagas](http://www.cs.cornell.edu/andru/cs711/2002fa/reading/sagas.pdf),” at
     *ACM International Conference on Management of Data* (SIGMOD), May 1987.
-    [doi:10.1145/38713.38742](https://dx.doi.org/10.1145/38713.38742)
+    [doi:10.1145/38713.38742](https://doi.org/10.1145/38713.38742)
 
 1.  C. Mohan, Bruce G. Lindsay, and Ron Obermarck:
     “[Transaction Management in the R* Distributed Database Management System](https://cs.brown.edu/courses/csci2270/archives/2012/papers/dtxn/p378-mohan.pdf),”
     *ACM Transactions on Database Systems*, volume 11, number 4, pages 378–396, December 1986.
-    [doi:10.1145/7239.7266](https://dx.doi.org/10.1145/7239.7266)
+    [doi:10.1145/7239.7266](https://doi.org/10.1145/7239.7266)
 
 1.  “[Distributed Transaction Processing: The XA Specification](http://pubs.opengroup.org/onlinepubs/009680699/toc.pdf),” X/Open Company Ltd., Technical Standard
     XO/CAE/91/300, December 1991. ISBN: 978-1-872-63024-3
@@ -329,20 +329,20 @@ Chapter 9 References
 1.  Ivan Silva Neto and Francisco Reverbel:
     “[Lessons Learned from Implementing WS-Coordination and WS-AtomicTransaction](http://www.ime.usp.br/~reverbel/papers/icis2008.pdf),” at *7th IEEE/ACIS International Conference on
     Computer and Information Science* (ICIS), May 2008.
-    [doi:10.1109/ICIS.2008.75](https://dx.doi.org/10.1109/ICIS.2008.75)
+    [doi:10.1109/ICIS.2008.75](https://doi.org/10.1109/ICIS.2008.75)
 
 1.  James E. Johnson, David E. Langworthy, Leslie Lamport, and Friedrich H. Vogt:
     “[Formal Specification of a Web Services Protocol](https://www.microsoft.com/en-us/research/publication/formal-specification-of-a-web-services-protocol/),”
     at *1st International Workshop on Web Services and Formal Methods* (WS-FM), February 2004.
-    [doi:10.1016/j.entcs.2004.02.022](https://dx.doi.org/10.1016/j.entcs.2004.02.022)
+    [doi:10.1016/j.entcs.2004.02.022](https://doi.org/10.1016/j.entcs.2004.02.022)
 
 1.  Dale Skeen:
     “[Nonblocking Commit Protocols](http://www.cs.utexas.edu/~lorenzo/corsi/cs380d/papers/Ske81.pdf),” at *ACM International Conference on Management of Data* (SIGMOD), April 1981.
-    [doi:10.1145/582318.582339](https://dx.doi.org/10.1145/582318.582339)
+    [doi:10.1145/582318.582339](https://doi.org/10.1145/582318.582339)
 
 1.  Gregor Hohpe:
     “[Your Coffee Shop Doesn’t Use Two-Phase Commit](http://www.martinfowler.com/ieeeSoftware/coffeeShop.pdf),” *IEEE Software*, volume 22, number 2, pages 64–66, March 2005.
-    [doi:10.1109/MS.2005.52](https://dx.doi.org/10.1109/MS.2005.52)
+    [doi:10.1109/MS.2005.52](https://doi.org/10.1109/MS.2005.52)
 
 1.  Pat Helland:
     “[Life Beyond Distributed Transactions: An Apostate’s Opinion](https://web.archive.org/web/20210303104924/http://www-db.cs.wisc.edu/cidr/cidr2007/papers/cidr07p15.pdf),” at *3rd Biennial Conference on Innovative Data Systems
@@ -378,17 +378,17 @@ Chapter 9 References
 
 1.  Cynthia Dwork, Nancy Lynch, and Larry Stockmeyer:
     “[Consensus in the Presence of Partial Synchrony](https://web.archive.org/web/20210318133551/https://www.net.t-labs.tu-berlin.de/~petr/ADC-07/papers/DLS88.pdf),” *Journal of the ACM*, volume 35, number 2, pages 288–323,
-    April 1988. [doi:10.1145/42282.42283](https://dx.doi.org/10.1145/42282.42283)
+    April 1988. [doi:10.1145/42282.42283](https://doi.org/10.1145/42282.42283)
 
 1.  Miguel Castro and Barbara H. Liskov:
     “[Practical Byzantine Fault Tolerance and Proactive Recovery](https://web.archive.org/web/20181123142540/http://zoo.cs.yale.edu/classes/cs426/2012/bib/castro02practical.pdf),” *ACM Transactions on Computer Systems*,
     volume 20, number 4, pages 396–461, November 2002.
-    [doi:10.1145/571637.571640](https://dx.doi.org/10.1145/571637.571640)
+    [doi:10.1145/571637.571640](https://doi.org/10.1145/571637.571640)
 
 1.  Brian M. Oki and Barbara H. Liskov:
     “[Viewstamped Replication: A New Primary Copy Method to Support Highly-Available Distributed Systems](http://www.cs.princeton.edu/courses/archive/fall11/cos518/papers/viewstamped.pdf),” at
     *7th ACM Symposium on Principles of Distributed Computing* (PODC), August 1988.
-    [doi:10.1145/62546.62549](https://dx.doi.org/10.1145/62546.62549)
+    [doi:10.1145/62546.62549](https://doi.org/10.1145/62546.62549)
 
 1.  Barbara H. Liskov and James Cowling:
     “[Viewstamped Replication Revisited](http://pmg.csail.mit.edu/papers/vr-revisited.pdf),”
@@ -397,7 +397,7 @@ Chapter 9 References
 1.  Leslie Lamport:
     “[The Part-Time Parliament](https://www.microsoft.com/en-us/research/publication/part-time-parliament/),”
     *ACM Transactions on Computer Systems*, volume 16, number 2, pages 133–169, May 1998.
-    [doi:10.1145/279227.279229](https://dx.doi.org/10.1145/279227.279229)
+    [doi:10.1145/279227.279229](https://doi.org/10.1145/279227.279229)
 
 1.  Leslie Lamport:
     “[Paxos Made Simple](https://www.microsoft.com/en-us/research/publication/paxos-made-simple/),” *ACM SIGACT News*, volume 32, number 4, pages 51–58, December 2001.
@@ -416,7 +416,7 @@ Chapter 9 References
 1.  Heidi Howard, Malte Schwarzkopf, Anil Madhavapeddy,
     and Jon Crowcroft: “[Raft Refloated: Do We Have Consensus?](https://web.archive.org/web/20230319151303/https://www.cl.cam.ac.uk/~ms705/pub/papers/2015-osr-raft.pdf),” *ACM SIGOPS Operating Systems Review*, volume 49,
     number 1, pages 12–21, January 2015.
-    [doi:10.1145/2723872.2723876](https://dx.doi.org/10.1145/2723872.2723876)
+    [doi:10.1145/2723872.2723876](https://doi.org/10.1145/2723872.2723876)
 
 1.  André Medeiros:
     “[ZooKeeper’s Atomic Broadcast Protocol: Theory and Practice](http://www.tcs.hut.fi/Studies/T-79.5001/reports/2012-deSouzaMedeiros.pdf),” Aalto University School of Science, March 20, 2012.
@@ -424,7 +424,7 @@ Chapter 9 References
 1.  Robbert van Renesse, Nicolas Schiper, and
     Fred B. Schneider: “[Vive La Différence: Paxos vs. Viewstamped Replication vs. Zab](http://arxiv.org/abs/1309.5671),” *IEEE Transactions on Dependable and Secure Computing*,
     volume 12, number 4, pages 472–484, September 2014.
-    [doi:10.1109/TDSC.2014.2355848](https://dx.doi.org/10.1109/TDSC.2014.2355848)
+    [doi:10.1109/TDSC.2014.2355848](https://doi.org/10.1109/TDSC.2014.2355848)
 
 1.  Will
     Portnoy: “[Lessons Learned from Implementing Paxos](http://blog.willportnoy.com/2012/06/lessons-learned-from-paxos.html),” *blog.willportnoy.com*, June 14, 2012.
@@ -432,12 +432,12 @@ Chapter 9 References
 1.  Heidi Howard, Dahlia Malkhi, and Alexander Spiegelman:
     “[Flexible Paxos: Quorum Intersection Revisited](https://drops.dagstuhl.de/opus/volltexte/2017/7094/pdf/LIPIcs-OPODIS-2016-25.pdf),”
     at *20th International Conference on Principles of Distributed Systems* (OPODIS), December 2016.
-    [doi:10.4230/LIPIcs.OPODIS.2016.25](https://dx.doi.org/10.4230/LIPIcs.OPODIS.2016.25)
+    [doi:10.4230/LIPIcs.OPODIS.2016.25](https://doi.org/10.4230/LIPIcs.OPODIS.2016.25)
 
 1.  Heidi Howard and Jon Crowcroft:
     “[Coracle: Evaluating Consensus at the Internet Edge](http://www.sigcomm.org/sites/default/files/ccr/papers/2015/August/2829988-2790010.pdf),”
     at *Annual Conference of the ACM Special Interest Group on Data Communication* (SIGCOMM), August 2015.
-    [doi:10.1145/2829988.2790010](https://dx.doi.org/10.1145/2829988.2790010)
+    [doi:10.1145/2829988.2790010](https://doi.org/10.1145/2829988.2790010)
 
 1.  Kyle Kingsbury:
     “[Call Me Maybe: Elasticsearch 1.5.0](https://aphyr.com/posts/323-call-me-maybe-elasticsearch-1-5-0),” *aphyr.com*, April 27, 2015.
@@ -453,4 +453,4 @@ Chapter 9 References
 1.  Kenneth P. Birman:
     “[A History of the Virtual Synchrony Replication Model](https://ptolemy.berkeley.edu/projects/truststc/pubs/713/History%20of%20the%20Virtual%20Synchrony%20Replication%20Model%202010.pdf),”
     in *Replication: Theory and Practice*, Springer LNCS volume 5959, chapter 6, pages 91–120, 2010.
-    ISBN: 978-3-642-11293-5, [doi:10.1007/978-3-642-11294-2_6](https://dx.doi.org/10.1007/978-3-642-11294-2_6)
+    ISBN: 978-3-642-11293-5, [doi:10.1007/978-3-642-11294-2_6](https://doi.org/10.1007/978-3-642-11294-2_6)

--- a/chapter-09-refs.md
+++ b/chapter-09-refs.md
@@ -6,7 +6,7 @@ Chapter 9 References
 
 1.  Peter Bailis and Ali Ghodsi:
     “[Eventual Consistency Today: Limitations, Extensions, and Beyond](http://queue.acm.org/detail.cfm?id=2462076),” *ACM Queue*, volume 11, number 3, pages 55-63, March 2013.
-    [doi:10.1145/2460276.2462076](http://dx.doi.org/10.1145/2460276.2462076)
+    [doi:10.1145/2460276.2462076](https://dx.doi.org/10.1145/2460276.2462076)
 
 1.  Prince Mahajan, Lorenzo Alvisi, and Mike Dahlin:
     “[Consistency, Availability, and Convergence](http://apps.cs.utexas.edu/tech_reports/reports/tr/TR-2036.pdf),” University of Texas at Austin, Department of Computer
@@ -25,12 +25,12 @@ Chapter 9 References
 1.  Maurice P. Herlihy and Jeannette M. Wing:
     “[Linearizability: A Correctness Condition for Concurrent Objects](http://cs.brown.edu/~mph/HerlihyW90/p463-herlihy.pdf),” *ACM Transactions on Programming
     Languages and Systems* (TOPLAS), volume 12, number 3, pages 463–492, July 1990.
-    [doi:10.1145/78969.78972](http://dx.doi.org/10.1145/78969.78972)
+    [doi:10.1145/78969.78972](https://dx.doi.org/10.1145/78969.78972)
 
 1.  Leslie Lamport:
     “[On interprocess communication](https://www.microsoft.com/en-us/research/publication/interprocess-communication-part-basic-formalism-part-ii-algorithms/),”
     *Distributed Computing*, volume 1, number 2, pages 77–101, June 1986.
-    [doi:10.1007/BF01786228](http://dx.doi.org/10.1007/BF01786228)
+    [doi:10.1007/BF01786228](https://dx.doi.org/10.1007/BF01786228)
 
 1.  David K. Gifford:
     “[Information Storage in a Decentralized Computer System](http://www.mirrorservice.org/sites/www.bitsavers.org/pdf/xerox/parc/techReports/CSL-81-8_Information_Storage_in_a_Decentralized_Computer_System.pdf),” Xerox Palo Alto Research Centers, CSL-81-8, June 1981.
@@ -77,7 +77,7 @@ Chapter 9 References
 1.  Flavio P. Junqueira, Benjamin C. Reed, and Marco Serafini:
       “[Zab: High-Performance Broadcast for Primary-Backup Systems](https://web.archive.org/web/20220419064903/https://marcoserafini.github.io/papers/zab.pdf),”
       at *41st IEEE International Conference on Dependable Systems and Networks* (DSN), June 2011.
-      [doi:10.1109/DSN.2011.5958223](http://dx.doi.org/10.1109/DSN.2011.5958223)
+      [doi:10.1109/DSN.2011.5958223](https://dx.doi.org/10.1109/DSN.2011.5958223)
 
 1.  Diego Ongaro and John K. Ousterhout:
       “[In Search of an Understandable Consensus Algorithm](https://www.usenix.org/system/files/conference/atc14/atc14-paper-ongaro.pdf),”
@@ -86,17 +86,17 @@ Chapter 9 References
 1.  Hagit Attiya, Amotz Bar-Noy, and Danny Dolev:
     “[Sharing Memory Robustly in Message-Passing Systems](http://www.cse.huji.ac.il/course/2004/dist/p124-attiya.pdf),”
     *Journal of the ACM*, volume 42, number 1, pages 124–142, January 1995.
-    [doi:10.1145/200836.200869](http://dx.doi.org/10.1145/200836.200869)
+    [doi:10.1145/200836.200869](https://dx.doi.org/10.1145/200836.200869)
 
 1.  Nancy Lynch and Alex Shvartsman:
     “[Robust Emulation of Shared Memory Using Dynamic Quorum-Acknowledged Broadcasts](http://groups.csail.mit.edu/tds/papers/Lynch/FTCS97.pdf),” at *27th Annual International Symposium on
     Fault-Tolerant Computing* (FTCS), June 1997.
-    [doi:10.1109/FTCS.1997.614100](http://dx.doi.org/10.1109/FTCS.1997.614100)
+    [doi:10.1109/FTCS.1997.614100](https://dx.doi.org/10.1109/FTCS.1997.614100)
 
 1.  Christian Cachin, Rachid Guerraoui, and Luís Rodrigues:
     [*Introduction to Reliable and Secure Distributed Programming*](http://www.distributedprogramming.net/),
     2nd edition. Springer, 2011. ISBN: 978-3-642-15259-7,
-    [doi:10.1007/978-3-642-15260-3](http://dx.doi.org/10.1007/978-3-642-15260-3)
+    [doi:10.1007/978-3-642-15260-3](https://dx.doi.org/10.1007/978-3-642-15260-3)
 
 1.  Sam Elliott, Mark Allen, and Martin Kleppmann:
     [personal communication](https://web.archive.org/web/20230620021338/https://twitter.com/lenary/status/654761711933648896),
@@ -109,29 +109,29 @@ Chapter 9 References
     “[Wait-Free Synchronization](https://cs.brown.edu/~mph/Herlihy91/p124-herlihy.pdf),”
     *ACM Transactions on Programming Languages and Systems* (TOPLAS), volume 13, number 1,
     pages 124–149, January 1991.
-    [doi:10.1145/114005.102808](http://dx.doi.org/10.1145/114005.102808)
+    [doi:10.1145/114005.102808](https://dx.doi.org/10.1145/114005.102808)
 
 1.  Armando Fox and Eric A. Brewer:
     “[Harvest, Yield, and Scalable Tolerant Systems](http://radlab.cs.berkeley.edu/people/fox/static/pubs/pdf/c18.pdf),” at *7th Workshop on Hot Topics in Operating
     Systems* (HotOS), March 1999.
-    [doi:10.1109/HOTOS.1999.798396](http://dx.doi.org/10.1109/HOTOS.1999.798396)
+    [doi:10.1109/HOTOS.1999.798396](https://dx.doi.org/10.1109/HOTOS.1999.798396)
 
 1.  Seth Gilbert and Nancy Lynch:
     “[Brewer’s Conjecture and the Feasibility of Consistent, Available, Partition-Tolerant Web Services](http://www.comp.nus.edu.sg/~gilbert/pubs/BrewersConjecture-SigAct.pdf),”
     *ACM SIGACT News*, volume 33, number 2, pages 51–59, June 2002.
-    [doi:10.1145/564585.564601](http://dx.doi.org/10.1145/564585.564601)
+    [doi:10.1145/564585.564601](https://dx.doi.org/10.1145/564585.564601)
 
 1.  Seth Gilbert and Nancy Lynch:
     “[Perspectives on the CAP Theorem](http://groups.csail.mit.edu/tds/papers/Gilbert/Brewer2.pdf),” *IEEE Computer Magazine*, volume 45, number 2, pages 30–36, February 2012.
-    [doi:10.1109/MC.2011.389](http://dx.doi.org/10.1109/MC.2011.389)
+    [doi:10.1109/MC.2011.389](https://dx.doi.org/10.1109/MC.2011.389)
 
 1.  Eric A. Brewer:
     “[CAP Twelve Years Later: How the 'Rules' Have Changed](https://web.archive.org/web/20221222092656/http://cs609.cs.ua.edu/CAP12.pdf),” *IEEE Computer Magazine*, volume 45, number 2, pages 23–29, February 2012.
-    [doi:10.1109/MC.2012.37](http://dx.doi.org/10.1109/MC.2012.37)
+    [doi:10.1109/MC.2012.37](https://dx.doi.org/10.1109/MC.2012.37)
 
 1.  Susan B. Davidson, Hector Garcia-Molina, and Dale Skeen:
     “[Consistency in Partitioned Networks](http://delab.csd.auth.gr/~dimitris/courses/mpc_fall05/papers/invalidation/acm_csur85_partitioned_network_consistency.pdf),” *ACM Computing Surveys*, volume 17, number 3, pages 341–370, September 1985.
-    [doi:10.1145/5505.5508](http://dx.doi.org/10.1145/5505.5508)
+    [doi:10.1145/5505.5508](https://dx.doi.org/10.1145/5505.5508)
 
 1.  Paul R. Johnson and Robert H. Thomas:
     “[RFC 677: The Maintenance of Duplicate Databases](https://tools.ietf.org/html/rfc677),” Network Working Group, January 27, 1975.
@@ -142,7 +142,7 @@ Chapter 9 References
 1.  Michael J. Fischer and Alan Michael:
     “[Sacrificing Serializability to Attain High Availability of Data in an Unreliable Network](http://www.cs.ucsb.edu/~agrawal/spring2011/ugrad/p70-fischer.pdf),” at
     *1st ACM Symposium on Principles of Database Systems* (PODS), March 1982.
-    [doi:10.1145/588111.588124](http://dx.doi.org/10.1145/588111.588124)
+    [doi:10.1145/588111.588124](https://dx.doi.org/10.1145/588111.588124)
 
 1.  Eric A. Brewer:
     “[NoSQL: Past, Present, Future](http://www.infoq.com/presentations/NoSQL-History),”
@@ -162,18 +162,18 @@ Chapter 9 References
 1.  Nancy A. Lynch:
     “[A Hundred Impossibility Proofs for Distributed Computing](http://groups.csail.mit.edu/tds/papers/Lynch/podc89.pdf),” at *8th ACM Symposium on Principles of Distributed
     Computing* (PODC), August 1989.
-    [doi:10.1145/72981.72982](http://dx.doi.org/10.1145/72981.72982)
+    [doi:10.1145/72981.72982](https://dx.doi.org/10.1145/72981.72982)
 
 1.  Hagit Attiya, Faith Ellen, and Adam Morrison:
     “[Limitations of Highly-Available Eventually-Consistent Data Stores](https://www.cs.tau.ac.il/~mad/publications/podc2015-replds.pdf),”
     at *ACM Symposium on Principles of Distributed Computing* (PODC), July 2015.
-    [doi:10.1145/2767386.2767419](http://dx.doi.org/10.1145/2767386.2767419)
+    [doi:10.1145/2767386.2767419](https://dx.doi.org/10.1145/2767386.2767419)
 
 1.  Peter Sewell, Susmit Sarkar,
     Scott Owens, et al.:
     “[x86-TSO: A Rigorous and Usable Programmer's Model for x86 Multiprocessors](http://www.cl.cam.ac.uk/~pes20/weakmemory/cacm.pdf),” *Communications of the ACM*,
     volume 53, number 7, pages 89–97, July 2010.
-    [doi:10.1145/1785414.1785443](http://dx.doi.org/10.1145/1785414.1785443)
+    [doi:10.1145/1785414.1785443](https://dx.doi.org/10.1145/1785414.1785443)
 
 1.  Martin Thompson:
     “[Memory Barriers/Fences](http://mechanical-sympathy.blogspot.co.uk/2011/07/memory-barriersfences.html),” *mechanical-sympathy.blogspot.co.uk*, July 24, 2011.
@@ -184,17 +184,17 @@ Chapter 9 References
 1.  Daniel J. Abadi:
     “[Consistency Tradeoffs in Modern Distributed Database System Design](http://cs-www.cs.yale.edu/homes/dna/papers/abadi-pacelc.pdf),” *IEEE Computer Magazine*,
     volume 45, number 2, pages 37–42, February 2012.
-    [doi:10.1109/MC.2012.33](http://dx.doi.org/10.1109/MC.2012.33)
+    [doi:10.1109/MC.2012.33](https://dx.doi.org/10.1109/MC.2012.33)
 
 1.  Hagit Attiya and Jennifer L. Welch:
     “[Sequential Consistency Versus Linearizability](http://courses.csail.mit.edu/6.852/01/papers/p91-attiya.pdf),” *ACM Transactions on Computer Systems* (TOCS),
     volume 12, number 2, pages 91–122, May 1994.
-    [doi:10.1145/176575.176576](http://dx.doi.org/10.1145/176575.176576)
+    [doi:10.1145/176575.176576](https://dx.doi.org/10.1145/176575.176576)
 
 1.  Mustaque Ahamad, Gil Neiger, James E. Burns, et al.:
       “[Causal   Memory: Definitions, Implementation, and Programming](http://www-i2.informatik.rwth-aachen.de/i2/fileadmin/user_upload/documents/Seminar_MCMM11/Causal_memory_1996.pdf),” *Distributed
       Computing*, volume 9, number 1, pages 37–49, March 1995.
-      [doi:10.1007/BF01784241](http://dx.doi.org/10.1007/BF01784241)
+      [doi:10.1007/BF01784241](https://dx.doi.org/10.1007/BF01784241)
 
 1.  Wyatt Lloyd, Michael J. Freedman,
     Michael Kaminsky, and David G. Andersen:
@@ -220,7 +220,7 @@ Chapter 9 References
     Carlos Baquero, and Victor Fonte:
     “[Concise Server-Wide Causality Management for Eventually Consistent Data Stores](https://web.archive.org/web/20220810205439/http://haslab.uminho.pt/tome/files/global_logical_clocks.pdf),” at *15th IFIP International
     Conference on Distributed Applications and Interoperable Systems* (DAIS), June 2015.
-    [doi:10.1007/978-3-319-19129-4_6](http://dx.doi.org/10.1007/978-3-319-19129-4_6)
+    [doi:10.1007/978-3-319-19129-4_6](https://dx.doi.org/10.1007/978-3-319-19129-4_6)
 
 1.  Rob Conery:
       “[A Better ID Generator for PostgreSQL](https://web.archive.org/web/20220118044729/http://rob.conery.io/2014/05/29/a-better-id-generator-for-postgresql/),” *rob.conery.io*, May 29, 2014.
@@ -228,17 +228,17 @@ Chapter 9 References
 1.  Leslie Lamport:
     “[Time, Clocks, and the Ordering of Events in a Distributed System](https://www.microsoft.com/en-us/research/publication/time-clocks-ordering-events-distributed-system/),”
     *Communications of the ACM*, volume 21, number 7, pages 558–565, July 1978.
-    [doi:10.1145/359545.359563](http://dx.doi.org/10.1145/359545.359563)
+    [doi:10.1145/359545.359563](https://dx.doi.org/10.1145/359545.359563)
 
 1.  Xavier Défago, André Schiper, and Péter Urbán:
     “[Total Order Broadcast and Multicast Algorithms: Taxonomy and Survey](https://dspace.jaist.ac.jp/dspace/bitstream/10119/4883/1/defago_et_al.pdf),” *ACM Computing
     Surveys*, volume 36, number 4, pages 372–421, December 2004.
-    [doi:10.1145/1041680.1041682](http://dx.doi.org/10.1145/1041680.1041682)
+    [doi:10.1145/1041680.1041682](https://dx.doi.org/10.1145/1041680.1041682)
 
 1.  Hagit Attiya and Jennifer Welch: *Distributed
     Computing: Fundamentals, Simulations and Advanced Topics*, 2nd edition.
     John Wiley & Sons, 2004. ISBN: 978-0-471-45324-6,
-    [doi:10.1002/0471478210](http://dx.doi.org/10.1002/0471478210)
+    [doi:10.1002/0471478210](https://dx.doi.org/10.1002/0471478210)
 
 1.  Mahesh
     Balakrishnan, Dahlia Malkhi, Vijayan Prabhakaran, et al.:
@@ -256,7 +256,7 @@ Chapter 9 References
 1.  Mahesh Balakrishnan, Dahlia Malkhi, Ted Wobber, et al.:
     “[Tango: Distributed Data Structures over a Shared Log](https://www.microsoft.com/en-us/research/publication/tango-distributed-data-structures-over-a-shared-log/),”
     at *24th ACM Symposium on Operating Systems Principles* (SOSP), November 2013.
-    [doi:10.1145/2517349.2522732](http://dx.doi.org/10.1145/2517349.2522732)
+    [doi:10.1145/2517349.2522732](https://dx.doi.org/10.1145/2517349.2522732)
 
 1.  Robbert van Renesse and Fred B. Schneider:
     “[Chain Replication for Supporting High Throughput and Availability](http://static.usenix.org/legacy/events/osdi04/tech/full_papers/renesse/renesse.pdf),” at *6th USENIX
@@ -265,7 +265,7 @@ Chapter 9 References
 1.  Leslie Lamport:
     “[How to Make a Multiprocessor Computer That Correctly Executes Multiprocess Programs](https://lamport.azurewebsites.net/pubs/multi.pdf),”
     *IEEE Transactions on Computers*, volume 28, number 9, pages 690–691, September 1979.
-    [doi:10.1109/TC.1979.1675439](http://dx.doi.org/10.1109/TC.1979.1675439)
+    [doi:10.1109/TC.1979.1675439](https://dx.doi.org/10.1109/TC.1979.1675439)
 
 1.  Enis Söztutar, Devaraj Das, and Carter Shanklin:
     “[Apache HBase High Availability at the Next Level](https://web.archive.org/web/20160405122821/http://hortonworks.com/blog/apache-hbase-high-availability-next-level/),”
@@ -274,16 +274,16 @@ Chapter 9 References
 1.  Brian F Cooper, Raghu Ramakrishnan, Utkarsh Srivastava, et al.:
     “[PNUTS: Yahoo!’s Hosted Data Serving Platform](http://www.mpi-sws.org/~druschel/courses/ds/papers/cooper-pnuts.pdf),” at *34th International Conference on Very Large Data
     Bases* (VLDB), August 2008.
-    [doi:10.14778/1454159.1454167](http://dx.doi.org/10.14778/1454159.1454167)
+    [doi:10.14778/1454159.1454167](https://dx.doi.org/10.14778/1454159.1454167)
 
 1.  Tushar Deepak Chandra and Sam Toueg:
     “[Unreliable Failure Detectors for Reliable Distributed Systems](http://courses.csail.mit.edu/6.852/08/papers/CT96-JACM.pdf),” *Journal of the ACM*,
     volume 43, number 2, pages 225–267, March 1996.
-    [doi:10.1145/226643.226647](http://dx.doi.org/10.1145/226643.226647)
+    [doi:10.1145/226643.226647](https://dx.doi.org/10.1145/226643.226647)
 
 1.  Michael J. Fischer, Nancy Lynch, and Michael S. Paterson:
     “[Impossibility of Distributed Consensus with One Faulty Process](https://groups.csail.mit.edu/tds/papers/Lynch/jacm85.pdf),” *Journal of the ACM*, volume 32, number 2, pages 374–382, April 1985.
-    [doi:10.1145/3149.214121](http://dx.doi.org/10.1145/3149.214121)
+    [doi:10.1145/3149.214121](https://dx.doi.org/10.1145/3149.214121)
 
 1.  Michael Ben-Or: “Another Advantage of Free
     Choice: Completely Asynchronous Agreement Protocols,” at *2nd ACM Symposium on Principles of
@@ -293,12 +293,12 @@ Chapter 9 References
 1.  Jim N. Gray and Leslie Lamport:
     “[Consensus on Transaction Commit](http://db.cs.berkeley.edu/cs286/papers/paxoscommit-tods2006.pdf),” *ACM Transactions on Database Systems* (TODS), volume 31,
     number 1, pages 133–160, March 2006.
-    [doi:10.1145/1132863.1132867](http://dx.doi.org/10.1145/1132863.1132867)
+    [doi:10.1145/1132863.1132867](https://dx.doi.org/10.1145/1132863.1132867)
 
 1.  Rachid Guerraoui:
     “[Revisiting the Relationship Between Non-Blocking Atomic Commitment and Consensus](https://citeseerx.ist.psu.edu/pdf/5d06489503b6f791aa56d2d7942359c2592e44b0),”
     at *9th International Workshop on Distributed Algorithms* (WDAG), September 1995.
-    [doi:10.1007/BFb0022140](http://dx.doi.org/10.1007/BFb0022140)
+    [doi:10.1007/BFb0022140](https://dx.doi.org/10.1007/BFb0022140)
 
 1.  Thanumalayan Sankaranarayana Pillai, Vijay Chidambaram,
     Ramnatthan Alagappan, et al.: “[All File Systems Are Not Created Equal: On the Complexity of Crafting Crash-Consistent Applications](http://research.cs.wisc.edu/wind/Publications/alice-osdi14.pdf),”
@@ -312,12 +312,12 @@ Chapter 9 References
 1.  Hector Garcia-Molina and Kenneth Salem:
     “[Sagas](http://www.cs.cornell.edu/andru/cs711/2002fa/reading/sagas.pdf),” at
     *ACM International Conference on Management of Data* (SIGMOD), May 1987.
-    [doi:10.1145/38713.38742](http://dx.doi.org/10.1145/38713.38742)
+    [doi:10.1145/38713.38742](https://dx.doi.org/10.1145/38713.38742)
 
 1.  C. Mohan, Bruce G. Lindsay, and Ron Obermarck:
     “[Transaction Management in the R* Distributed Database Management System](https://cs.brown.edu/courses/csci2270/archives/2012/papers/dtxn/p378-mohan.pdf),”
     *ACM Transactions on Database Systems*, volume 11, number 4, pages 378–396, December 1986.
-    [doi:10.1145/7239.7266](http://dx.doi.org/10.1145/7239.7266)
+    [doi:10.1145/7239.7266](https://dx.doi.org/10.1145/7239.7266)
 
 1.  “[Distributed Transaction Processing: The XA Specification](http://pubs.opengroup.org/onlinepubs/009680699/toc.pdf),” X/Open Company Ltd., Technical Standard
     XO/CAE/91/300, December 1991. ISBN: 978-1-872-63024-3
@@ -329,20 +329,20 @@ Chapter 9 References
 1.  Ivan Silva Neto and Francisco Reverbel:
     “[Lessons Learned from Implementing WS-Coordination and WS-AtomicTransaction](http://www.ime.usp.br/~reverbel/papers/icis2008.pdf),” at *7th IEEE/ACIS International Conference on
     Computer and Information Science* (ICIS), May 2008.
-    [doi:10.1109/ICIS.2008.75](http://dx.doi.org/10.1109/ICIS.2008.75)
+    [doi:10.1109/ICIS.2008.75](https://dx.doi.org/10.1109/ICIS.2008.75)
 
 1.  James E. Johnson, David E. Langworthy, Leslie Lamport, and Friedrich H. Vogt:
     “[Formal Specification of a Web Services Protocol](https://www.microsoft.com/en-us/research/publication/formal-specification-of-a-web-services-protocol/),”
     at *1st International Workshop on Web Services and Formal Methods* (WS-FM), February 2004.
-    [doi:10.1016/j.entcs.2004.02.022](http://dx.doi.org/10.1016/j.entcs.2004.02.022)
+    [doi:10.1016/j.entcs.2004.02.022](https://dx.doi.org/10.1016/j.entcs.2004.02.022)
 
 1.  Dale Skeen:
     “[Nonblocking Commit Protocols](http://www.cs.utexas.edu/~lorenzo/corsi/cs380d/papers/Ske81.pdf),” at *ACM International Conference on Management of Data* (SIGMOD), April 1981.
-    [doi:10.1145/582318.582339](http://dx.doi.org/10.1145/582318.582339)
+    [doi:10.1145/582318.582339](https://dx.doi.org/10.1145/582318.582339)
 
 1.  Gregor Hohpe:
     “[Your Coffee Shop Doesn’t Use Two-Phase Commit](http://www.martinfowler.com/ieeeSoftware/coffeeShop.pdf),” *IEEE Software*, volume 22, number 2, pages 64–66, March 2005.
-    [doi:10.1109/MS.2005.52](http://dx.doi.org/10.1109/MS.2005.52)
+    [doi:10.1109/MS.2005.52](https://dx.doi.org/10.1109/MS.2005.52)
 
 1.  Pat Helland:
     “[Life Beyond Distributed Transactions: An Apostate’s Opinion](https://web.archive.org/web/20210303104924/http://www-db.cs.wisc.edu/cidr/cidr2007/papers/cidr07p15.pdf),” at *3rd Biennial Conference on Innovative Data Systems
@@ -378,17 +378,17 @@ Chapter 9 References
 
 1.  Cynthia Dwork, Nancy Lynch, and Larry Stockmeyer:
     “[Consensus in the Presence of Partial Synchrony](https://web.archive.org/web/20210318133551/https://www.net.t-labs.tu-berlin.de/~petr/ADC-07/papers/DLS88.pdf),” *Journal of the ACM*, volume 35, number 2, pages 288–323,
-    April 1988. [doi:10.1145/42282.42283](http://dx.doi.org/10.1145/42282.42283)
+    April 1988. [doi:10.1145/42282.42283](https://dx.doi.org/10.1145/42282.42283)
 
 1.  Miguel Castro and Barbara H. Liskov:
     “[Practical Byzantine Fault Tolerance and Proactive Recovery](https://web.archive.org/web/20181123142540/http://zoo.cs.yale.edu/classes/cs426/2012/bib/castro02practical.pdf),” *ACM Transactions on Computer Systems*,
     volume 20, number 4, pages 396–461, November 2002.
-    [doi:10.1145/571637.571640](http://dx.doi.org/10.1145/571637.571640)
+    [doi:10.1145/571637.571640](https://dx.doi.org/10.1145/571637.571640)
 
 1.  Brian M. Oki and Barbara H. Liskov:
     “[Viewstamped Replication: A New Primary Copy Method to Support Highly-Available Distributed Systems](http://www.cs.princeton.edu/courses/archive/fall11/cos518/papers/viewstamped.pdf),” at
     *7th ACM Symposium on Principles of Distributed Computing* (PODC), August 1988.
-    [doi:10.1145/62546.62549](http://dx.doi.org/10.1145/62546.62549)
+    [doi:10.1145/62546.62549](https://dx.doi.org/10.1145/62546.62549)
 
 1.  Barbara H. Liskov and James Cowling:
     “[Viewstamped Replication Revisited](http://pmg.csail.mit.edu/papers/vr-revisited.pdf),”
@@ -397,7 +397,7 @@ Chapter 9 References
 1.  Leslie Lamport:
     “[The Part-Time Parliament](https://www.microsoft.com/en-us/research/publication/part-time-parliament/),”
     *ACM Transactions on Computer Systems*, volume 16, number 2, pages 133–169, May 1998.
-    [doi:10.1145/279227.279229](http://dx.doi.org/10.1145/279227.279229)
+    [doi:10.1145/279227.279229](https://dx.doi.org/10.1145/279227.279229)
 
 1.  Leslie Lamport:
     “[Paxos Made Simple](https://www.microsoft.com/en-us/research/publication/paxos-made-simple/),” *ACM SIGACT News*, volume 32, number 4, pages 51–58, December 2001.
@@ -416,7 +416,7 @@ Chapter 9 References
 1.  Heidi Howard, Malte Schwarzkopf, Anil Madhavapeddy,
     and Jon Crowcroft: “[Raft Refloated: Do We Have Consensus?](https://web.archive.org/web/20230319151303/https://www.cl.cam.ac.uk/~ms705/pub/papers/2015-osr-raft.pdf),” *ACM SIGOPS Operating Systems Review*, volume 49,
     number 1, pages 12–21, January 2015.
-    [doi:10.1145/2723872.2723876](http://dx.doi.org/10.1145/2723872.2723876)
+    [doi:10.1145/2723872.2723876](https://dx.doi.org/10.1145/2723872.2723876)
 
 1.  André Medeiros:
     “[ZooKeeper’s Atomic Broadcast Protocol: Theory and Practice](http://www.tcs.hut.fi/Studies/T-79.5001/reports/2012-deSouzaMedeiros.pdf),” Aalto University School of Science, March 20, 2012.
@@ -424,7 +424,7 @@ Chapter 9 References
 1.  Robbert van Renesse, Nicolas Schiper, and
     Fred B. Schneider: “[Vive La Différence: Paxos vs. Viewstamped Replication vs. Zab](http://arxiv.org/abs/1309.5671),” *IEEE Transactions on Dependable and Secure Computing*,
     volume 12, number 4, pages 472–484, September 2014.
-    [doi:10.1109/TDSC.2014.2355848](http://dx.doi.org/10.1109/TDSC.2014.2355848)
+    [doi:10.1109/TDSC.2014.2355848](https://dx.doi.org/10.1109/TDSC.2014.2355848)
 
 1.  Will
     Portnoy: “[Lessons Learned from Implementing Paxos](http://blog.willportnoy.com/2012/06/lessons-learned-from-paxos.html),” *blog.willportnoy.com*, June 14, 2012.
@@ -432,12 +432,12 @@ Chapter 9 References
 1.  Heidi Howard, Dahlia Malkhi, and Alexander Spiegelman:
     “[Flexible Paxos: Quorum Intersection Revisited](https://drops.dagstuhl.de/opus/volltexte/2017/7094/pdf/LIPIcs-OPODIS-2016-25.pdf),”
     at *20th International Conference on Principles of Distributed Systems* (OPODIS), December 2016.
-    [doi:10.4230/LIPIcs.OPODIS.2016.25](http://dx.doi.org/10.4230/LIPIcs.OPODIS.2016.25)
+    [doi:10.4230/LIPIcs.OPODIS.2016.25](https://dx.doi.org/10.4230/LIPIcs.OPODIS.2016.25)
 
 1.  Heidi Howard and Jon Crowcroft:
     “[Coracle: Evaluating Consensus at the Internet Edge](http://www.sigcomm.org/sites/default/files/ccr/papers/2015/August/2829988-2790010.pdf),”
     at *Annual Conference of the ACM Special Interest Group on Data Communication* (SIGCOMM), August 2015.
-    [doi:10.1145/2829988.2790010](http://dx.doi.org/10.1145/2829988.2790010)
+    [doi:10.1145/2829988.2790010](https://dx.doi.org/10.1145/2829988.2790010)
 
 1.  Kyle Kingsbury:
     “[Call Me Maybe: Elasticsearch 1.5.0](https://aphyr.com/posts/323-call-me-maybe-elasticsearch-1-5-0),” *aphyr.com*, April 27, 2015.
@@ -453,5 +453,4 @@ Chapter 9 References
 1.  Kenneth P. Birman:
     “[A History of the Virtual Synchrony Replication Model](https://ptolemy.berkeley.edu/projects/truststc/pubs/713/History%20of%20the%20Virtual%20Synchrony%20Replication%20Model%202010.pdf),”
     in *Replication: Theory and Practice*, Springer LNCS volume 5959, chapter 6, pages 91–120, 2010.
-    ISBN: 978-3-642-11293-5, [doi:10.1007/978-3-642-11294-2_6](http://dx.doi.org/10.1007/978-3-642-11294-2_6)
-
+    ISBN: 978-3-642-11293-5, [doi:10.1007/978-3-642-11294-2_6](https://dx.doi.org/10.1007/978-3-642-11294-2_6)

--- a/chapter-10-refs.md
+++ b/chapter-10-refs.md
@@ -14,7 +14,7 @@ Chapter 10 References
 1.  Shivnath Babu and Herodotos Herodotou:
     “[Massively Parallel Databases and MapReduce Systems](https://www.microsoft.com/en-us/research/wp-content/uploads/2013/11/db-mr-survey-final.pdf),”
     *Foundations and Trends in Databases*, volume 5, number 1, pages 1–104, November 2013.
-    [doi:10.1561/1900000036](http://dx.doi.org/10.1561/1900000036)
+    [doi:10.1561/1900000036](https://dx.doi.org/10.1561/1900000036)
 
 1.  David J. DeWitt and Michael Stonebraker:
     “[MapReduce: A Major Step Backwards](https://homes.cs.washington.edu/~billhowe/mapreduce_a_major_step_backwards.html),” originally published at *databasecolumn.vertica.com*, January 17, 2008.
@@ -72,11 +72,11 @@ Chapter 10 References
 1.  Sanjay Ghemawat, Howard Gobioff, and Shun-Tak
     Leung: “[The Google File System](http://research.google.com/archive/gfs-sosp2003.pdf),”
     at *19th ACM Symposium on Operating Systems Principles* (SOSP), October 2003.
-    [doi:10.1145/945445.945450](http://dx.doi.org/10.1145/945445.945450)
+    [doi:10.1145/945445.945450](https://dx.doi.org/10.1145/945445.945450)
 
 1.  Michael Ovsiannikov, Silvius Rus, Damian Reeves, et al.:
     “[The Quantcast File System](http://db.disi.unitn.eu/pages/VLDBProgram/pdf/industry/p808-ovsiannikov.pdf),” *Proceedings of the VLDB Endowment*, volume 6, number 11, pages 1092–1101, August 2013.
-    [doi:10.14778/2536222.2536234](http://dx.doi.org/10.14778/2536222.2536234)
+    [doi:10.14778/2536222.2536234](https://dx.doi.org/10.14778/2536222.2536234)
 
 1.  “[OpenStack Swift 2.6.1 Developer Documentation](http://docs.openstack.org/developer/swift/),” OpenStack Foundation, *docs.openstack.org*, March 2016.
 
@@ -109,7 +109,7 @@ Chapter 10 References
 1.  Roshan Sumbaly, Jay Kreps, and Sam Shah:
     “[The 'Big Data' Ecosystem at LinkedIn](http://www.slideshare.net/s_shah/the-big-data-ecosystem-at-linkedin-23512853),” at *ACM International Conference on Management of Data*
     (SIGMOD), July 2013.
-    [doi:10.1145/2463676.2463707](http://dx.doi.org/10.1145/2463676.2463707)
+    [doi:10.1145/2463676.2463707](https://dx.doi.org/10.1145/2463676.2463707)
 
 1.  Alan F. Gates, Olga Natkovich, Shubham Chopra, et al.:
     “[Building a High-Level Dataflow System on Top of Map-Reduce: The Pig Experience](http://www.vldb.org/pvldb/vol2/vldb09-1074.pdf),”
@@ -117,7 +117,7 @@ Chapter 10 References
 
 1.  Ashish Thusoo, Joydeep Sen Sarma, Namit Jain, et al.:
     “[Hive – A Petabyte Scale Data Warehouse Using Hadoop](http://i.stanford.edu/~ragho/hive-icde2010.pdf),” at *26th IEEE International Conference on Data Engineering* (ICDE), March 2010.
-    [doi:10.1109/ICDE.2010.5447738](http://dx.doi.org/10.1109/ICDE.2010.5447738)
+    [doi:10.1109/ICDE.2010.5447738](https://dx.doi.org/10.1109/ICDE.2010.5447738)
 
 1.  “[Cascading 3.0 User Guide](http://docs.cascading.org/cascading/3.0/userguide/),” Concurrent, Inc., *docs.cascading.org*, January 2016.
 
@@ -126,7 +126,7 @@ Chapter 10 References
 1.  Craig Chambers, Ashish Raniwala, Frances
     Perry, et al.: “[FlumeJava: Easy, Efficient Data-Parallel Pipelines](https://research.google.com/pubs/archive/35650.pdf),” at *31st ACM SIGPLAN Conference on Programming Language
     Design and Implementation* (PLDI), June 2010.
-    [doi:10.1145/1806596.1806638](http://dx.doi.org/10.1145/1806596.1806638)
+    [doi:10.1145/1806596.1806638](https://dx.doi.org/10.1145/1806596.1806638)
 
 1.  Jay Kreps:
     “[Why Local State is a Fundamental Primitive in Stream Processing](https://www.oreilly.com/ideas/why-local-state-is-a-fundamental-primitive-in-stream-processing),” *oreilly.com*, July 31, 2014.
@@ -193,7 +193,7 @@ Chapter 10 References
 1.  David J. DeWitt and Jim N. Gray:
     “[Parallel Database Systems: The Future of High Performance Database Systems](http://www.cs.cmu.edu/~pavlo/courses/fall2013/static/papers/dewittgray92.pdf),”
     *Communications of the ACM*, volume 35, number 6, pages 85–98, June 1992.
-    [doi:10.1145/129888.129894](http://dx.doi.org/10.1145/129888.129894)
+    [doi:10.1145/129888.129894](https://dx.doi.org/10.1145/129888.129894)
 
 1.  Jay Kreps:
     “[But the multi-tenancy thing is actually really really hard](https://twitter.com/jaykreps/status/528235702480142336),” tweetstorm, *twitter.com*, October 31, 2014.
@@ -201,7 +201,7 @@ Chapter 10 References
 1.  Jeffrey Cohen, Brian Dolan, Mark Dunlap, et al.:
     “[MAD Skills: New Analysis Practices for Big Data](http://www.vldb.org/pvldb/vol2/vldb09-219.pdf),”
     *Proceedings of the VLDB Endowment*, volume 2, number 2, pages 1481–1492, August 2009.
-    [doi:10.14778/1687553.1687576](http://dx.doi.org/10.14778/1687553.1687576)
+    [doi:10.14778/1687553.1687576](https://dx.doi.org/10.14778/1687553.1687576)
 
 1.  Ignacio
     Terrizzano, Peter Schwarz, Mary Roth, and John E. Colino:
@@ -217,11 +217,11 @@ Chapter 10 References
 
 1.  Vinod Kumar Vavilapalli, Arun C. Murthy, Chris Douglas, et al.:
     “[Apache Hadoop YARN: Yet Another Resource Negotiator](http://www.socc2013.org/home/program/a5-vavilapalli.pdf),” at *4th ACM Symposium on Cloud Computing* (SoCC), October 2013.
-    [doi:10.1145/2523616.2523633](http://dx.doi.org/10.1145/2523616.2523633)
+    [doi:10.1145/2523616.2523633](https://dx.doi.org/10.1145/2523616.2523633)
 
 1.  Abhishek Verma, Luis Pedrosa, Madhukar Korupolu, et al.:
     “[Large-Scale Cluster Management at Google with Borg](http://research.google.com/pubs/pub43438.html),” at *10th European Conference on Computer Systems* (EuroSys), April 2015.
-    [doi:10.1145/2741948.2741964](http://dx.doi.org/10.1145/2741948.2741964)
+    [doi:10.1145/2741948.2741964](https://dx.doi.org/10.1145/2741948.2741964)
 
 1.  Malte Schwarzkopf:
     “[The Evolution of Cluster Scheduler Architectures](https://web.archive.org/web/20201109052657/http://www.firmament.io/blog/scheduler-architectures.html),” *firmament.io*, March 9, 2016.
@@ -239,24 +239,24 @@ Chapter 10 References
 1.  Bikas Saha, Hitesh Shah, Siddharth Seth, et al.:
     “[Apache Tez: A Unifying Framework for Modeling and Building Data Processing Applications](http://home.cse.ust.hk/~weiwa/teaching/Fall15-COMP6611B/reading_list/Tez.pdf),” at *ACM
     International Conference on Management of Data* (SIGMOD), June 2015.
-    [doi:10.1145/2723372.2742790](http://dx.doi.org/10.1145/2723372.2742790)
+    [doi:10.1145/2723372.2742790](https://dx.doi.org/10.1145/2723372.2742790)
 
 1.  Kostas Tzoumas:
     “[Apache Flink: API, Runtime, and Project Roadmap](http://www.slideshare.net/KostasTzoumas/apache-flink-api-runtime-and-project-roadmap),” *slideshare.net*, January 14, 2015.
 
 1.  Alexander Alexandrov, Rico Bergmann, Stephan Ewen, et al.:
     “[The Stratosphere Platform for Big Data Analytics](https://ssc.io/pdf/2014-VLDBJ_Stratosphere_Overview.pdf),” *The VLDB Journal*, volume 23, number 6, pages 939–964, May 2014.
-    [doi:10.1007/s00778-014-0357-y](http://dx.doi.org/10.1007/s00778-014-0357-y)
+    [doi:10.1007/s00778-014-0357-y](https://dx.doi.org/10.1007/s00778-014-0357-y)
 
 1.  Michael Isard, Mihai Budiu, Yuan Yu, et al.:
     “[Dryad: Distributed Data-Parallel Programs from Sequential Building Blocks](https://www.microsoft.com/en-us/research/publication/dryad-distributed-data-parallel-programs-from-sequential-building-blocks/),” at *European Conference on Computer
     Systems* (EuroSys), March 2007.
-    [doi:10.1145/1272996.1273005](http://dx.doi.org/10.1145/1272996.1273005)
+    [doi:10.1145/1272996.1273005](https://dx.doi.org/10.1145/1272996.1273005)
 
 1.  Daniel Warneke and Odej Kao:
     “[Nephele: Efficient Parallel Data Processing in the Cloud](https://stratosphere2.dima.tu-berlin.de/assets/papers/Nephele_09.pdf),” at *2nd Workshop on Many-Task Computing on Grids and
     Supercomputers* (MTAGS), November 2009.
-    [doi:10.1145/1646468.1646476](http://dx.doi.org/10.1145/1646468.1646476)
+    [doi:10.1145/1646468.1646476](https://dx.doi.org/10.1145/1646468.1646476)
 
 1.  Lawrence Page, Sergey Brin, Rajeev Motwani, and Terry Winograd:
     “[The PageRank Citation Ranking: Bringing Order to the Web](https://web.archive.org/web/20230219170930/http://ilpubs.stanford.edu:8090/422/),”
@@ -265,16 +265,16 @@ Chapter 10 References
 1.  Leslie G. Valiant:
     “[A Bridging Model for Parallel Computation](http://dl.acm.org/citation.cfm?id=79181),”
     *Communications of the ACM*, volume 33, number 8, pages 103–111, August 1990.
-    [doi:10.1145/79173.79181](http://dx.doi.org/10.1145/79173.79181)
+    [doi:10.1145/79173.79181](https://dx.doi.org/10.1145/79173.79181)
 
 1.  Stephan Ewen, Kostas Tzoumas, Moritz Kaufmann, and Volker Markl:
     “[Spinning Fast Iterative Data Flows](http://vldb.org/pvldb/vol5/p1268_stephanewen_vldb2012.pdf),” *Proceedings of the VLDB Endowment*, volume 5, number 11, pages 1268-1279, July 2012.
-    [doi:10.14778/2350229.2350245](http://dx.doi.org/10.14778/2350229.2350245)
+    [doi:10.14778/2350229.2350245](https://dx.doi.org/10.14778/2350229.2350245)
 
 1.  Grzegorz Malewicz, Matthew H.
     Austern, Aart J. C. Bik, et al.: “[Pregel: A System for Large-Scale Graph Processing](https://kowshik.github.io/JPregel/pregel_paper.pdf),” at *ACM International Conference on Management of
     Data* (SIGMOD), June 2010.
-    [doi:10.1145/1807167.1807184](http://dx.doi.org/10.1145/1807167.1807184)
+    [doi:10.1145/1807167.1807184](https://dx.doi.org/10.1145/1807167.1807184)
 
 1.  Frank McSherry, Michael Isard, and Derek G. Murray:
     “[Scalability! But at What COST?](http://www.frankmcsherry.org/assets/COST.pdf),” at
@@ -283,7 +283,7 @@ Chapter 10 References
 1.  Ionel Gog, Malte Schwarzkopf, Natacha Crooks, et al.:
     “[Musketeer: All for One, One for All in Data Processing Systems](http://www.cl.cam.ac.uk/research/srg/netos/camsas/pubs/eurosys15-musketeer.pdf),” at *10th European Conference on
     Computer Systems* (EuroSys), April 2015.
-    [doi:10.1145/2741948.2741968](http://dx.doi.org/10.1145/2741948.2741968)
+    [doi:10.1145/2741948.2741968](https://dx.doi.org/10.1145/2741948.2741968)
 
 1.  Aapo Kyrola, Guy Blelloch, and Carlos Guestrin:
     “[GraphChi: Large-Scale Graph Computation on Just a PC](https://www.usenix.org/system/files/conference/osdi12/osdi12-final-126.pdf),” at *10th USENIX Symposium on Operating Systems
@@ -291,7 +291,7 @@ Chapter 10 References
 
 1.  Andrew Lenharth, Donald Nguyen, and Keshav Pingali:
     “[Parallel Graph Analytics](http://cacm.acm.org/magazines/2016/5/201591-parallel-graph-analytics/fulltext),” *Communications of the ACM*, volume 59, number 5, pages 78–87, May
-    2016. [doi:10.1145/2901919](http://dx.doi.org/10.1145/2901919)
+    2016. [doi:10.1145/2901919](https://dx.doi.org/10.1145/2901919)
 
 1.  Fabian Hüske:
     “[Peeking into Apache Flink's Engine Room](http://flink.apache.org/news/2015/03/13/peeking-into-Apache-Flinks-Engine-Room.html),” *flink.apache.org*, March 13, 2015.
@@ -302,7 +302,7 @@ Chapter 10 References
 
 1.  Michael Armbrust, Reynold S Xin, Cheng Lian, et al.:
     “[Spark SQL: Relational Data Processing in Spark](http://people.csail.mit.edu/matei/papers/2015/sigmod_spark_sql.pdf),” at *ACM International Conference on Management of Data* (SIGMOD), June 2015.
-    [doi:10.1145/2723372.2742797](http://dx.doi.org/10.1145/2723372.2742797)
+    [doi:10.1145/2723372.2742797](https://dx.doi.org/10.1145/2723372.2742797)
 
 1.  Daniel Blazevski:
     “[Planting Quadtrees for Apache Flink](https://blog.insightdatascience.com/planting-quadtrees-for-apache-flink-b396ebc80d35),” *insightdataengineering.com*, March 25, 2016.

--- a/chapter-10-refs.md
+++ b/chapter-10-refs.md
@@ -14,7 +14,7 @@ Chapter 10 References
 1.  Shivnath Babu and Herodotos Herodotou:
     “[Massively Parallel Databases and MapReduce Systems](https://www.microsoft.com/en-us/research/wp-content/uploads/2013/11/db-mr-survey-final.pdf),”
     *Foundations and Trends in Databases*, volume 5, number 1, pages 1–104, November 2013.
-    [doi:10.1561/1900000036](https://dx.doi.org/10.1561/1900000036)
+    [doi:10.1561/1900000036](https://doi.org/10.1561/1900000036)
 
 1.  David J. DeWitt and Michael Stonebraker:
     “[MapReduce: A Major Step Backwards](https://homes.cs.washington.edu/~billhowe/mapreduce_a_major_step_backwards.html),” originally published at *databasecolumn.vertica.com*, January 17, 2008.
@@ -72,11 +72,11 @@ Chapter 10 References
 1.  Sanjay Ghemawat, Howard Gobioff, and Shun-Tak
     Leung: “[The Google File System](http://research.google.com/archive/gfs-sosp2003.pdf),”
     at *19th ACM Symposium on Operating Systems Principles* (SOSP), October 2003.
-    [doi:10.1145/945445.945450](https://dx.doi.org/10.1145/945445.945450)
+    [doi:10.1145/945445.945450](https://doi.org/10.1145/945445.945450)
 
 1.  Michael Ovsiannikov, Silvius Rus, Damian Reeves, et al.:
     “[The Quantcast File System](http://db.disi.unitn.eu/pages/VLDBProgram/pdf/industry/p808-ovsiannikov.pdf),” *Proceedings of the VLDB Endowment*, volume 6, number 11, pages 1092–1101, August 2013.
-    [doi:10.14778/2536222.2536234](https://dx.doi.org/10.14778/2536222.2536234)
+    [doi:10.14778/2536222.2536234](https://doi.org/10.14778/2536222.2536234)
 
 1.  “[OpenStack Swift 2.6.1 Developer Documentation](http://docs.openstack.org/developer/swift/),” OpenStack Foundation, *docs.openstack.org*, March 2016.
 
@@ -109,7 +109,7 @@ Chapter 10 References
 1.  Roshan Sumbaly, Jay Kreps, and Sam Shah:
     “[The 'Big Data' Ecosystem at LinkedIn](http://www.slideshare.net/s_shah/the-big-data-ecosystem-at-linkedin-23512853),” at *ACM International Conference on Management of Data*
     (SIGMOD), July 2013.
-    [doi:10.1145/2463676.2463707](https://dx.doi.org/10.1145/2463676.2463707)
+    [doi:10.1145/2463676.2463707](https://doi.org/10.1145/2463676.2463707)
 
 1.  Alan F. Gates, Olga Natkovich, Shubham Chopra, et al.:
     “[Building a High-Level Dataflow System on Top of Map-Reduce: The Pig Experience](http://www.vldb.org/pvldb/vol2/vldb09-1074.pdf),”
@@ -117,7 +117,7 @@ Chapter 10 References
 
 1.  Ashish Thusoo, Joydeep Sen Sarma, Namit Jain, et al.:
     “[Hive – A Petabyte Scale Data Warehouse Using Hadoop](http://i.stanford.edu/~ragho/hive-icde2010.pdf),” at *26th IEEE International Conference on Data Engineering* (ICDE), March 2010.
-    [doi:10.1109/ICDE.2010.5447738](https://dx.doi.org/10.1109/ICDE.2010.5447738)
+    [doi:10.1109/ICDE.2010.5447738](https://doi.org/10.1109/ICDE.2010.5447738)
 
 1.  “[Cascading 3.0 User Guide](http://docs.cascading.org/cascading/3.0/userguide/),” Concurrent, Inc., *docs.cascading.org*, January 2016.
 
@@ -126,7 +126,7 @@ Chapter 10 References
 1.  Craig Chambers, Ashish Raniwala, Frances
     Perry, et al.: “[FlumeJava: Easy, Efficient Data-Parallel Pipelines](https://research.google.com/pubs/archive/35650.pdf),” at *31st ACM SIGPLAN Conference on Programming Language
     Design and Implementation* (PLDI), June 2010.
-    [doi:10.1145/1806596.1806638](https://dx.doi.org/10.1145/1806596.1806638)
+    [doi:10.1145/1806596.1806638](https://doi.org/10.1145/1806596.1806638)
 
 1.  Jay Kreps:
     “[Why Local State is a Fundamental Primitive in Stream Processing](https://www.oreilly.com/ideas/why-local-state-is-a-fundamental-primitive-in-stream-processing),” *oreilly.com*, July 31, 2014.
@@ -193,7 +193,7 @@ Chapter 10 References
 1.  David J. DeWitt and Jim N. Gray:
     “[Parallel Database Systems: The Future of High Performance Database Systems](http://www.cs.cmu.edu/~pavlo/courses/fall2013/static/papers/dewittgray92.pdf),”
     *Communications of the ACM*, volume 35, number 6, pages 85–98, June 1992.
-    [doi:10.1145/129888.129894](https://dx.doi.org/10.1145/129888.129894)
+    [doi:10.1145/129888.129894](https://doi.org/10.1145/129888.129894)
 
 1.  Jay Kreps:
     “[But the multi-tenancy thing is actually really really hard](https://twitter.com/jaykreps/status/528235702480142336),” tweetstorm, *twitter.com*, October 31, 2014.
@@ -201,7 +201,7 @@ Chapter 10 References
 1.  Jeffrey Cohen, Brian Dolan, Mark Dunlap, et al.:
     “[MAD Skills: New Analysis Practices for Big Data](http://www.vldb.org/pvldb/vol2/vldb09-219.pdf),”
     *Proceedings of the VLDB Endowment*, volume 2, number 2, pages 1481–1492, August 2009.
-    [doi:10.14778/1687553.1687576](https://dx.doi.org/10.14778/1687553.1687576)
+    [doi:10.14778/1687553.1687576](https://doi.org/10.14778/1687553.1687576)
 
 1.  Ignacio
     Terrizzano, Peter Schwarz, Mary Roth, and John E. Colino:
@@ -217,11 +217,11 @@ Chapter 10 References
 
 1.  Vinod Kumar Vavilapalli, Arun C. Murthy, Chris Douglas, et al.:
     “[Apache Hadoop YARN: Yet Another Resource Negotiator](http://www.socc2013.org/home/program/a5-vavilapalli.pdf),” at *4th ACM Symposium on Cloud Computing* (SoCC), October 2013.
-    [doi:10.1145/2523616.2523633](https://dx.doi.org/10.1145/2523616.2523633)
+    [doi:10.1145/2523616.2523633](https://doi.org/10.1145/2523616.2523633)
 
 1.  Abhishek Verma, Luis Pedrosa, Madhukar Korupolu, et al.:
     “[Large-Scale Cluster Management at Google with Borg](http://research.google.com/pubs/pub43438.html),” at *10th European Conference on Computer Systems* (EuroSys), April 2015.
-    [doi:10.1145/2741948.2741964](https://dx.doi.org/10.1145/2741948.2741964)
+    [doi:10.1145/2741948.2741964](https://doi.org/10.1145/2741948.2741964)
 
 1.  Malte Schwarzkopf:
     “[The Evolution of Cluster Scheduler Architectures](https://web.archive.org/web/20201109052657/http://www.firmament.io/blog/scheduler-architectures.html),” *firmament.io*, March 9, 2016.
@@ -239,24 +239,24 @@ Chapter 10 References
 1.  Bikas Saha, Hitesh Shah, Siddharth Seth, et al.:
     “[Apache Tez: A Unifying Framework for Modeling and Building Data Processing Applications](http://home.cse.ust.hk/~weiwa/teaching/Fall15-COMP6611B/reading_list/Tez.pdf),” at *ACM
     International Conference on Management of Data* (SIGMOD), June 2015.
-    [doi:10.1145/2723372.2742790](https://dx.doi.org/10.1145/2723372.2742790)
+    [doi:10.1145/2723372.2742790](https://doi.org/10.1145/2723372.2742790)
 
 1.  Kostas Tzoumas:
     “[Apache Flink: API, Runtime, and Project Roadmap](http://www.slideshare.net/KostasTzoumas/apache-flink-api-runtime-and-project-roadmap),” *slideshare.net*, January 14, 2015.
 
 1.  Alexander Alexandrov, Rico Bergmann, Stephan Ewen, et al.:
     “[The Stratosphere Platform for Big Data Analytics](https://ssc.io/pdf/2014-VLDBJ_Stratosphere_Overview.pdf),” *The VLDB Journal*, volume 23, number 6, pages 939–964, May 2014.
-    [doi:10.1007/s00778-014-0357-y](https://dx.doi.org/10.1007/s00778-014-0357-y)
+    [doi:10.1007/s00778-014-0357-y](https://doi.org/10.1007/s00778-014-0357-y)
 
 1.  Michael Isard, Mihai Budiu, Yuan Yu, et al.:
     “[Dryad: Distributed Data-Parallel Programs from Sequential Building Blocks](https://www.microsoft.com/en-us/research/publication/dryad-distributed-data-parallel-programs-from-sequential-building-blocks/),” at *European Conference on Computer
     Systems* (EuroSys), March 2007.
-    [doi:10.1145/1272996.1273005](https://dx.doi.org/10.1145/1272996.1273005)
+    [doi:10.1145/1272996.1273005](https://doi.org/10.1145/1272996.1273005)
 
 1.  Daniel Warneke and Odej Kao:
     “[Nephele: Efficient Parallel Data Processing in the Cloud](https://stratosphere2.dima.tu-berlin.de/assets/papers/Nephele_09.pdf),” at *2nd Workshop on Many-Task Computing on Grids and
     Supercomputers* (MTAGS), November 2009.
-    [doi:10.1145/1646468.1646476](https://dx.doi.org/10.1145/1646468.1646476)
+    [doi:10.1145/1646468.1646476](https://doi.org/10.1145/1646468.1646476)
 
 1.  Lawrence Page, Sergey Brin, Rajeev Motwani, and Terry Winograd:
     “[The PageRank Citation Ranking: Bringing Order to the Web](https://web.archive.org/web/20230219170930/http://ilpubs.stanford.edu:8090/422/),”
@@ -265,16 +265,16 @@ Chapter 10 References
 1.  Leslie G. Valiant:
     “[A Bridging Model for Parallel Computation](http://dl.acm.org/citation.cfm?id=79181),”
     *Communications of the ACM*, volume 33, number 8, pages 103–111, August 1990.
-    [doi:10.1145/79173.79181](https://dx.doi.org/10.1145/79173.79181)
+    [doi:10.1145/79173.79181](https://doi.org/10.1145/79173.79181)
 
 1.  Stephan Ewen, Kostas Tzoumas, Moritz Kaufmann, and Volker Markl:
     “[Spinning Fast Iterative Data Flows](http://vldb.org/pvldb/vol5/p1268_stephanewen_vldb2012.pdf),” *Proceedings of the VLDB Endowment*, volume 5, number 11, pages 1268-1279, July 2012.
-    [doi:10.14778/2350229.2350245](https://dx.doi.org/10.14778/2350229.2350245)
+    [doi:10.14778/2350229.2350245](https://doi.org/10.14778/2350229.2350245)
 
 1.  Grzegorz Malewicz, Matthew H.
     Austern, Aart J. C. Bik, et al.: “[Pregel: A System for Large-Scale Graph Processing](https://kowshik.github.io/JPregel/pregel_paper.pdf),” at *ACM International Conference on Management of
     Data* (SIGMOD), June 2010.
-    [doi:10.1145/1807167.1807184](https://dx.doi.org/10.1145/1807167.1807184)
+    [doi:10.1145/1807167.1807184](https://doi.org/10.1145/1807167.1807184)
 
 1.  Frank McSherry, Michael Isard, and Derek G. Murray:
     “[Scalability! But at What COST?](http://www.frankmcsherry.org/assets/COST.pdf),” at
@@ -283,7 +283,7 @@ Chapter 10 References
 1.  Ionel Gog, Malte Schwarzkopf, Natacha Crooks, et al.:
     “[Musketeer: All for One, One for All in Data Processing Systems](http://www.cl.cam.ac.uk/research/srg/netos/camsas/pubs/eurosys15-musketeer.pdf),” at *10th European Conference on
     Computer Systems* (EuroSys), April 2015.
-    [doi:10.1145/2741948.2741968](https://dx.doi.org/10.1145/2741948.2741968)
+    [doi:10.1145/2741948.2741968](https://doi.org/10.1145/2741948.2741968)
 
 1.  Aapo Kyrola, Guy Blelloch, and Carlos Guestrin:
     “[GraphChi: Large-Scale Graph Computation on Just a PC](https://www.usenix.org/system/files/conference/osdi12/osdi12-final-126.pdf),” at *10th USENIX Symposium on Operating Systems
@@ -291,7 +291,7 @@ Chapter 10 References
 
 1.  Andrew Lenharth, Donald Nguyen, and Keshav Pingali:
     “[Parallel Graph Analytics](http://cacm.acm.org/magazines/2016/5/201591-parallel-graph-analytics/fulltext),” *Communications of the ACM*, volume 59, number 5, pages 78–87, May
-    2016. [doi:10.1145/2901919](https://dx.doi.org/10.1145/2901919)
+    2016. [doi:10.1145/2901919](https://doi.org/10.1145/2901919)
 
 1.  Fabian Hüske:
     “[Peeking into Apache Flink's Engine Room](http://flink.apache.org/news/2015/03/13/peeking-into-Apache-Flinks-Engine-Room.html),” *flink.apache.org*, March 13, 2015.
@@ -302,7 +302,7 @@ Chapter 10 References
 
 1.  Michael Armbrust, Reynold S Xin, Cheng Lian, et al.:
     “[Spark SQL: Relational Data Processing in Spark](http://people.csail.mit.edu/matei/papers/2015/sigmod_spark_sql.pdf),” at *ACM International Conference on Management of Data* (SIGMOD), June 2015.
-    [doi:10.1145/2723372.2742797](https://dx.doi.org/10.1145/2723372.2742797)
+    [doi:10.1145/2723372.2742797](https://doi.org/10.1145/2723372.2742797)
 
 1.  Daniel Blazevski:
     “[Planting Quadtrees for Apache Flink](https://blog.insightdatascience.com/planting-quadtrees-for-apache-flink-b396ebc80d35),” *insightdataengineering.com*, March 25, 2016.

--- a/chapter-11-refs.md
+++ b/chapter-11-refs.md
@@ -7,7 +7,7 @@ Chapter 11 References
 1.  Tyler Akidau, Robert Bradshaw, Craig Chambers, et al.:
     “[The Dataflow Model: A Practical Approach to Balancing Correctness, Latency, and Cost in Massive-Scale, Unbounded, Out-of-Order Data Processing](http://www.vldb.org/pvldb/vol8/p1792-Akidau.pdf),”
     *Proceedings of the VLDB Endowment*, volume 8, number 12, pages 1792–1803, August 2015.
-    [doi:10.14778/2824032.2824076](https://dx.doi.org/10.14778/2824032.2824076)
+    [doi:10.14778/2824032.2824076](https://doi.org/10.14778/2824032.2824076)
 
 1.  Harold Abelson, Gerald Jay Sussman, and Julie Sussman:
     [*Structure and Interpretation of Computer Programs*](https://web.archive.org/web/20220807043536/https://mitpress.mit.edu/sites/default/files/sicp/index.html),
@@ -17,7 +17,7 @@ Chapter 11 References
     Rachid Guerraoui, and Anne-Marie Kermarrec:
     “[The Many Faces of Publish/Subscribe](http://www.cs.ru.nl/~pieter/oss/manyfaces.pdf),”
     *ACM Computing Surveys*, volume 35, number 2, pages 114–131, June 2003.
-    [doi:10.1145/857076.857078](https://dx.doi.org/10.1145/857076.857078)
+    [doi:10.1145/857076.857078](https://doi.org/10.1145/857076.857078)
 
 1.  Joseph M. Hellerstein and Michael Stonebraker:
     [*Readings in Database Systems*](http://redbook.cs.berkeley.edu/), 4th edition.
@@ -158,7 +158,7 @@ Chapter 11 References
 1.  H. V. Jagadish, Inderpal Singh Mumick, and Abraham Silberschatz:
     “[View Maintenance Issues for the Chronicle Data Model](https://dl.acm.org/doi/10.1145/212433.220201),”
     at *14th ACM SIGACT-SIGMOD-SIGART Symposium on Principles of Database Systems* (PODS), May 1995.
-    [doi:10.1145/212433.220201](https://dx.doi.org/10.1145/212433.220201)
+    [doi:10.1145/212433.220201](https://doi.org/10.1145/212433.220201)
 
 1.  “[Event Store 3.5.0 Documentation](http://docs.geteventstore.com/),” Event Store LLP, *docs.geteventstore.com*, February 2016.
 
@@ -179,7 +179,7 @@ Chapter 11 References
 1.  Timothy Griffin and Leonid Libkin:
     “[Incremental Maintenance of Views with Duplicates](http://homepages.inf.ed.ac.uk/libkin/papers/sigmod95.pdf),” at *ACM International Conference on Management of
     Data* (SIGMOD), May 1995.
-    [doi:10.1145/223784.223849](https://dx.doi.org/10.1145/223784.223849)
+    [doi:10.1145/223784.223849](https://doi.org/10.1145/223784.223849)
 
 1.  Pat Helland:
     “[Immutability Changes Everything](http://cidrdb.org/cidr2015/Papers/CIDR15_Paper16.pdf),”
@@ -231,11 +231,11 @@ Chapter 11 References
 1.  Arvind Arasu, Shivnath Babu, and Jennifer Widom:
     “[The CQL Continuous Query Language: Semantic Foundations and Query Execution](https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/cql.pdf),”
     *The VLDB Journal*, volume 15, number 2, pages 121–142, June 2006.
-    [doi:10.1007/s00778-004-0147-z](https://dx.doi.org/10.1007/s00778-004-0147-z)
+    [doi:10.1007/s00778-004-0147-z](https://doi.org/10.1007/s00778-004-0147-z)
 
 1.  Julian Hyde:
     “[Data in Flight: How Streaming SQL Technology Can Help Solve the Web 2.0 Data Crunch](http://queue.acm.org/detail.cfm?id=1667562),” *ACM Queue*, volume 7, number 11, December 2009.
-    [doi:10.1145/1661785.1667562](https://dx.doi.org/10.1145/1661785.1667562)
+    [doi:10.1145/1661785.1667562](https://doi.org/10.1145/1661785.1667562)
 
 1.  “[Esper Reference, Version 5.4.0](http://esper.espertech.com/release-5.4.0/esper-reference/html_single/index.html),”
     EsperTech, Inc., *espertech.com*, April 2016.
@@ -246,7 +246,7 @@ Chapter 11 References
 1.  Milinda Pathirage, Julian Hyde, Yi Pan, and Beth Plale:
     “[SamzaSQL: Scalable Fast Data Management with Streaming SQL](https://github.com/milinda/samzasql-hpbdc2016/blob/master/samzasql-hpbdc2016.pdf),” at *IEEE International Workshop on
     High-Performance Big Data Computing* (HPBDC), May 2016.
-    [doi:10.1109/IPDPSW.2016.141](https://dx.doi.org/10.1109/IPDPSW.2016.141)
+    [doi:10.1109/IPDPSW.2016.141](https://doi.org/10.1109/IPDPSW.2016.141)
 
 1.  Philippe Flajolet, Éric Fusy, Olivier
     Gandouet, and Frédéric Meunier:
@@ -293,7 +293,7 @@ Chapter 11 References
     Venkatesh Basker, Sumit Das, et al.:
     “[Photon: Fault-Tolerant and Scalable Joining of Continuous Data Streams](http://research.google.com/pubs/pub41318.html),” at *ACM International Conference on Management of
     Data* (SIGMOD), June 2013.
-    [doi:10.1145/2463676.2465272](https://dx.doi.org/10.1145/2463676.2465272)
+    [doi:10.1145/2463676.2465272](https://doi.org/10.1145/2463676.2465272)
 
 1.  Martin Kleppmann:
     “[Samza Newsfeed Demo](https://github.com/ept/newsfeed),” *github.com*,
@@ -336,7 +336,7 @@ Chapter 11 References
 
 1.  Pat Helland:
     “[Idempotence Is Not a Medical Condition](https://citeseerx.ist.psu.edu/document?repid=rep1&type=pdf&doi=4b6dda7fe75b51e1c543a87ca7b3b322fbf55614),” *Communications of the ACM*, volume 55, number 5, page 56, May 2012.
-    [doi:10.1145/2160718.2160734](https://dx.doi.org/10.1145/2160718.2160734)
+    [doi:10.1145/2160718.2160734](https://doi.org/10.1145/2160718.2160734)
 
 1.  Jay Kreps:
     “[Re: Trying to Achieve Deterministic Behavior on Recovery/Rewind](http://mail-archives.apache.org/mod_mbox/samza-dev/201409.mbox/%3CCAOeJiJg%2Bc7Ei%3DgzCuOz30DD3G5Hm9yFY%3DUJ6SafdNUFbvRgorg%40mail.gmail.com%3E),” email to *samza-dev* mailing list,
@@ -346,7 +346,7 @@ Chapter 11 References
     Lorenzo Alvisi, Yi-Min Wang, and David B. Johnson:
     “[A Survey of Rollback-Recovery Protocols in Message-Passing Systems](http://www.cs.utexas.edu/~lorenzo/papers/SurveyFinal.pdf),” *ACM Computing Surveys*, volume 34, number 3,
     pages 375–408, September 2002.
-    [doi:10.1145/568522.568525](https://dx.doi.org/10.1145/568522.568525)
+    [doi:10.1145/568522.568525](https://doi.org/10.1145/568522.568525)
 
 1.  Adam Warski:
     “[Kafka Streams – How Does It Fit the Stream Processing Landscape?](https://softwaremill.com/kafka-streams-how-does-it-fit-stream-landscape/),” *softwaremill.com*, June 1, 2016.

--- a/chapter-11-refs.md
+++ b/chapter-11-refs.md
@@ -7,7 +7,7 @@ Chapter 11 References
 1.  Tyler Akidau, Robert Bradshaw, Craig Chambers, et al.:
     “[The Dataflow Model: A Practical Approach to Balancing Correctness, Latency, and Cost in Massive-Scale, Unbounded, Out-of-Order Data Processing](http://www.vldb.org/pvldb/vol8/p1792-Akidau.pdf),”
     *Proceedings of the VLDB Endowment*, volume 8, number 12, pages 1792–1803, August 2015.
-    [doi:10.14778/2824032.2824076](http://dx.doi.org/10.14778/2824032.2824076)
+    [doi:10.14778/2824032.2824076](https://dx.doi.org/10.14778/2824032.2824076)
 
 1.  Harold Abelson, Gerald Jay Sussman, and Julie Sussman:
     [*Structure and Interpretation of Computer Programs*](https://web.archive.org/web/20220807043536/https://mitpress.mit.edu/sites/default/files/sicp/index.html),
@@ -17,7 +17,7 @@ Chapter 11 References
     Rachid Guerraoui, and Anne-Marie Kermarrec:
     “[The Many Faces of Publish/Subscribe](http://www.cs.ru.nl/~pieter/oss/manyfaces.pdf),”
     *ACM Computing Surveys*, volume 35, number 2, pages 114–131, June 2003.
-    [doi:10.1145/857076.857078](http://dx.doi.org/10.1145/857076.857078)
+    [doi:10.1145/857076.857078](https://dx.doi.org/10.1145/857076.857078)
 
 1.  Joseph M. Hellerstein and Michael Stonebraker:
     [*Readings in Database Systems*](http://redbook.cs.berkeley.edu/), 4th edition.
@@ -158,7 +158,7 @@ Chapter 11 References
 1.  H. V. Jagadish, Inderpal Singh Mumick, and Abraham Silberschatz:
     “[View Maintenance Issues for the Chronicle Data Model](https://dl.acm.org/doi/10.1145/212433.220201),”
     at *14th ACM SIGACT-SIGMOD-SIGART Symposium on Principles of Database Systems* (PODS), May 1995.
-    [doi:10.1145/212433.220201](http://dx.doi.org/10.1145/212433.220201)
+    [doi:10.1145/212433.220201](https://dx.doi.org/10.1145/212433.220201)
 
 1.  “[Event Store 3.5.0 Documentation](http://docs.geteventstore.com/),” Event Store LLP, *docs.geteventstore.com*, February 2016.
 
@@ -179,7 +179,7 @@ Chapter 11 References
 1.  Timothy Griffin and Leonid Libkin:
     “[Incremental Maintenance of Views with Duplicates](http://homepages.inf.ed.ac.uk/libkin/papers/sigmod95.pdf),” at *ACM International Conference on Management of
     Data* (SIGMOD), May 1995.
-    [doi:10.1145/223784.223849](http://dx.doi.org/10.1145/223784.223849)
+    [doi:10.1145/223784.223849](https://dx.doi.org/10.1145/223784.223849)
 
 1.  Pat Helland:
     “[Immutability Changes Everything](http://cidrdb.org/cidr2015/Papers/CIDR15_Paper16.pdf),”
@@ -231,11 +231,11 @@ Chapter 11 References
 1.  Arvind Arasu, Shivnath Babu, and Jennifer Widom:
     “[The CQL Continuous Query Language: Semantic Foundations and Query Execution](https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/cql.pdf),”
     *The VLDB Journal*, volume 15, number 2, pages 121–142, June 2006.
-    [doi:10.1007/s00778-004-0147-z](http://dx.doi.org/10.1007/s00778-004-0147-z)
+    [doi:10.1007/s00778-004-0147-z](https://dx.doi.org/10.1007/s00778-004-0147-z)
 
 1.  Julian Hyde:
     “[Data in Flight: How Streaming SQL Technology Can Help Solve the Web 2.0 Data Crunch](http://queue.acm.org/detail.cfm?id=1667562),” *ACM Queue*, volume 7, number 11, December 2009.
-    [doi:10.1145/1661785.1667562](http://dx.doi.org/10.1145/1661785.1667562)
+    [doi:10.1145/1661785.1667562](https://dx.doi.org/10.1145/1661785.1667562)
 
 1.  “[Esper Reference, Version 5.4.0](http://esper.espertech.com/release-5.4.0/esper-reference/html_single/index.html),”
     EsperTech, Inc., *espertech.com*, April 2016.
@@ -246,7 +246,7 @@ Chapter 11 References
 1.  Milinda Pathirage, Julian Hyde, Yi Pan, and Beth Plale:
     “[SamzaSQL: Scalable Fast Data Management with Streaming SQL](https://github.com/milinda/samzasql-hpbdc2016/blob/master/samzasql-hpbdc2016.pdf),” at *IEEE International Workshop on
     High-Performance Big Data Computing* (HPBDC), May 2016.
-    [doi:10.1109/IPDPSW.2016.141](http://dx.doi.org/10.1109/IPDPSW.2016.141)
+    [doi:10.1109/IPDPSW.2016.141](https://dx.doi.org/10.1109/IPDPSW.2016.141)
 
 1.  Philippe Flajolet, Éric Fusy, Olivier
     Gandouet, and Frédéric Meunier:
@@ -293,7 +293,7 @@ Chapter 11 References
     Venkatesh Basker, Sumit Das, et al.:
     “[Photon: Fault-Tolerant and Scalable Joining of Continuous Data Streams](http://research.google.com/pubs/pub41318.html),” at *ACM International Conference on Management of
     Data* (SIGMOD), June 2013.
-    [doi:10.1145/2463676.2465272](http://dx.doi.org/10.1145/2463676.2465272)
+    [doi:10.1145/2463676.2465272](https://dx.doi.org/10.1145/2463676.2465272)
 
 1.  Martin Kleppmann:
     “[Samza Newsfeed Demo](https://github.com/ept/newsfeed),” *github.com*,
@@ -336,7 +336,7 @@ Chapter 11 References
 
 1.  Pat Helland:
     “[Idempotence Is Not a Medical Condition](https://citeseerx.ist.psu.edu/document?repid=rep1&type=pdf&doi=4b6dda7fe75b51e1c543a87ca7b3b322fbf55614),” *Communications of the ACM*, volume 55, number 5, page 56, May 2012.
-    [doi:10.1145/2160718.2160734](http://dx.doi.org/10.1145/2160718.2160734)
+    [doi:10.1145/2160718.2160734](https://dx.doi.org/10.1145/2160718.2160734)
 
 1.  Jay Kreps:
     “[Re: Trying to Achieve Deterministic Behavior on Recovery/Rewind](http://mail-archives.apache.org/mod_mbox/samza-dev/201409.mbox/%3CCAOeJiJg%2Bc7Ei%3DgzCuOz30DD3G5Hm9yFY%3DUJ6SafdNUFbvRgorg%40mail.gmail.com%3E),” email to *samza-dev* mailing list,
@@ -346,8 +346,7 @@ Chapter 11 References
     Lorenzo Alvisi, Yi-Min Wang, and David B. Johnson:
     “[A Survey of Rollback-Recovery Protocols in Message-Passing Systems](http://www.cs.utexas.edu/~lorenzo/papers/SurveyFinal.pdf),” *ACM Computing Surveys*, volume 34, number 3,
     pages 375–408, September 2002.
-    [doi:10.1145/568522.568525](http://dx.doi.org/10.1145/568522.568525)
+    [doi:10.1145/568522.568525](https://dx.doi.org/10.1145/568522.568525)
 
 1.  Adam Warski:
     “[Kafka Streams – How Does It Fit the Stream Processing Landscape?](https://softwaremill.com/kafka-streams-how-does-it-fit-stream-landscape/),” *softwaremill.com*, June 1, 2016.
-

--- a/chapter-12-refs.md
+++ b/chapter-12-refs.md
@@ -62,7 +62,7 @@ Chapter 12 References
 1.  Dennis M. Ritchie and Ken Thompson:
     “[The UNIX Time-Sharing System](http://web.eecs.utk.edu/~qcao1/cs560/papers/paper-unix.pdf),”
     *Communications of the ACM*, volume 17, number 7, pages 365–375, July 1974.
-    [doi:10.1145/361011.361061](http://dx.doi.org/10.1145/361011.361061)
+    [doi:10.1145/361011.361061](https://dx.doi.org/10.1145/361011.361061)
 
 1.  Eric A. Brewer and Joseph M. Hellerstein:
     “[CS262a: Advanced Topics in Computer Systems](http://people.eecs.berkeley.edu/~brewer/cs262/systemr.html),” lecture notes, University of California, Berkeley, *cs.berkeley.edu*,
@@ -75,7 +75,7 @@ Chapter 12 References
 1.  Jennie Duggan,
       Aaron J. Elmore, Michael Stonebraker, et al.:
       “[The BigDAWG Polystore   System](https://dspace.mit.edu/handle/1721.1/100936),” *ACM SIGMOD Record*, volume 44, number 2, pages 11–16, June 2015.
-      [doi:10.1145/2814710.2814713](http://dx.doi.org/10.1145/2814710.2814713)
+      [doi:10.1145/2814710.2814713](https://dx.doi.org/10.1145/2814710.2814713)
 
 1.  Patrycja Dybka:
       “[Foreign   Data Wrappers for PostgreSQL](http://www.vertabelo.com/blog/technical-articles/foreign-data-wrappers-for-postgresql),” *vertabelo.com*, March 24, 2015.
@@ -98,7 +98,7 @@ Chapter 12 References
 1.  Derek G Murray, Frank McSherry, Rebecca Isaacs, et al.:
     “[Naiad: A Timely Dataflow System](http://sigops.org/s/conferences/sosp/2013/papers/p439-murray.pdf),”
     at *24th ACM Symposium on Operating Systems Principles* (SOSP), pages 439–455, November 2013.
-    [doi:10.1145/2517349.2522738](http://dx.doi.org/10.1145/2517349.2522738)
+    [doi:10.1145/2517349.2522738](https://dx.doi.org/10.1145/2517349.2522738)
 
 1.  Gwen Shapira:
     “[We have a bunch of customers who are implementing ‘database inside-out’ concept and they all ask ‘is anyone else doing it? are we crazy?’](https://twitter.com/gwenshap/status/758800071110430720)” *twitter.com*, July 28, 2016.
@@ -115,12 +115,12 @@ Chapter 12 References
 1.  Evan Czaplicki and Stephen Chong:
     “[Asynchronous Functional Reactive Programming for GUIs](http://people.seas.harvard.edu/~chong/pubs/pldi13-elm.pdf),” at *34th ACM SIGPLAN Conference on Programming Language
     Design and Implementation* (PLDI), June 2013.
-    [doi:10.1145/2491956.2462161](http://dx.doi.org/10.1145/2491956.2462161)
+    [doi:10.1145/2491956.2462161](https://dx.doi.org/10.1145/2491956.2462161)
 
 1.  Engineer Bainomugisha, Andoni Lombide Carreton,
     Tom van Cutsem, Stijn Mostinckx, and Wolfgang de Meuter:
     “[A Survey on Reactive Programming](http://soft.vub.ac.be/Publications/2012/vub-soft-tr-12-13.pdf),” *ACM Computing Surveys*, volume 45, number 4, pages 1–34, August 2013.
-    [doi:10.1145/2501654.2501666](http://dx.doi.org/10.1145/2501654.2501666)
+    [doi:10.1145/2501654.2501666](https://dx.doi.org/10.1145/2501654.2501666)
 
 1.  Peter Alvaro, Neil Conway, Joseph M. Hellerstein, and William R. Marczak:
     “[Consistency Analysis in Bloom: A CALM and Collected Approach](https://dsf.berkeley.edu/cs286/papers/calm-cidr2011.pdf),”
@@ -139,7 +139,7 @@ Chapter 12 References
 1.  Peter Bailis, Alan Fekete, Michael J Franklin,
     et al.: “[Feral Concurrency Control: An Empirical Investigation of Modern Application Integrity](http://www.bailis.org/papers/feral-sigmod2015.pdf),” at *ACM International Conference on
     Management of Data* (SIGMOD), June 2015.
-    [doi:10.1145/2723372.2737784](http://dx.doi.org/10.1145/2723372.2737784)
+    [doi:10.1145/2723372.2737784](https://dx.doi.org/10.1145/2723372.2737784)
 
 1.  Guy Steele:
     “[Re: Need for Macros (Was Re: Icon)](https://people.csail.mit.edu/gregs/ll1-discuss-archive-html/msg01134.html),” email to *ll1-discuss* mailing list, *people.csail.mit.edu*, December 24,
@@ -148,13 +148,13 @@ Chapter 12 References
 1.  David Gelernter:
     “[Generative Communication in Linda](http://cseweb.ucsd.edu/groups/csag/html/teaching/cse291s03/Readings/p80-gelernter.pdf),” *ACM Transactions on Programming Languages and Systems*
     (TOPLAS), volume 7, number 1, pages 80–112, January 1985.
-    [doi:10.1145/2363.2433](http://dx.doi.org/10.1145/2363.2433)
+    [doi:10.1145/2363.2433](https://dx.doi.org/10.1145/2363.2433)
 
 1.  Patrick Th. Eugster, Pascal A. Felber,
     Rachid Guerraoui, and Anne-Marie Kermarrec:
     “[The Many Faces of Publish/Subscribe](http://www.cs.ru.nl/~pieter/oss/manyfaces.pdf),”
     *ACM Computing Surveys*, volume 35, number 2, pages 114–131, June 2003.
-    [doi:10.1145/857076.857078](http://dx.doi.org/10.1145/857076.857078)
+    [doi:10.1145/857076.857078](https://dx.doi.org/10.1145/857076.857078)
 
 1.  Ben Stopford:
     “[Microservices in a Streaming World](https://www.infoq.com/presentations/microservices-streaming),” at *QCon London*, March 2016.
@@ -170,7 +170,7 @@ Chapter 12 References
     Protzenko, and Manuel Fähndrich:
     “[Global Sequence Protocol: A Robust Abstraction for Replicated Shared State](http://drops.dagstuhl.de/opus/volltexte/2015/5238/),” at *29th European Conference on Object-Oriented
     Programming* (ECOOP), July 2015.
-    [doi:10.4230/LIPIcs.ECOOP.2015.568](http://dx.doi.org/10.4230/LIPIcs.ECOOP.2015.568)
+    [doi:10.4230/LIPIcs.ECOOP.2015.568](https://dx.doi.org/10.4230/LIPIcs.ECOOP.2015.568)
 
 1.  Mark Soper:
     “[Clearing Up React Data Management Confusion with Flux, Redux, and Relay](https://medium.com/@marksoper/clearing-up-react-data-management-confusion-with-flux-redux-and-relay-aad504e63cae),” *medium.com*, December 3, 2015.
@@ -199,7 +199,7 @@ Chapter 12 References
 1.  Arthur J. Bernstein, Philip M. Lewis, and Shiyong Lu:
     “[Semantic Conditions for Correctness at Different Isolation Levels](http://db.cs.berkeley.edu/cs286/papers/isolation-icde2000.pdf),” at *16th International Conference on Data
     Engineering* (ICDE), February 2000.
-    [doi:10.1109/ICDE.2000.839387](http://dx.doi.org/10.1109/ICDE.2000.839387)
+    [doi:10.1109/ICDE.2000.839387](https://dx.doi.org/10.1109/ICDE.2000.839387)
 
 1.  Sudhir Jorwekar, Alan Fekete, Krithi Ramamritham, and
     S. Sudarshan: “[Automating the Detection of Snapshot Isolation Anomalies](http://www.vldb.org/conf/2007/papers/industrial/p1263-jorwekar.pdf),” at *33rd International Conference on Very
@@ -215,7 +215,7 @@ Chapter 12 References
 1.  Jerome H. Saltzer, David P. Reed, and David D. Clark:
     “[End-to-End Arguments in System Design](https://groups.csail.mit.edu/ana/Publications/PubPDFs/End-to-End%20Arguments%20in%20System%20Design.pdf),”
     *ACM Transactions on Computer Systems*, volume 2, number 4, pages 277–288, November 1984.
-    [doi:10.1145/357401.357402](http://dx.doi.org/10.1145/357401.357402)
+    [doi:10.1145/357401.357402](https://dx.doi.org/10.1145/357401.357402)
 
 1.  Peter Bailis, Alan Fekete, Michael J. Franklin, et al.:
     “[Coordination-Avoiding Database Systems](http://arxiv.org/pdf/1402.2237.pdf),”
@@ -227,7 +227,7 @@ Chapter 12 References
 1.  Douglas B Terry, Marvin M Theimer, Karin Petersen, et al.:
     “[Managing Update Conflicts in Bayou, a Weakly Connected Replicated Storage System](http://css.csail.mit.edu/6.824/2014/papers/bayou-conflicts.pdf),” at *15th ACM Symposium on Operating
     Systems Principles* (SOSP), pages 172–182, December 1995.
-    [doi:10.1145/224056.224070](http://dx.doi.org/10.1145/224056.224070)
+    [doi:10.1145/224056.224070](https://dx.doi.org/10.1145/224056.224070)
 
 1.  Jim Gray:
       “[The Transaction Concept: Virtues and Limitations](http://jimgray.azurewebsites.net/papers/thetransactionconcept.pdf),”
@@ -236,7 +236,7 @@ Chapter 12 References
 1.  Hector Garcia-Molina and Kenneth Salem:
       “[Sagas](http://www.cs.cornell.edu/andru/cs711/2002fa/reading/sagas.pdf),” at
       *ACM International Conference on Management of Data* (SIGMOD), May 1987.
-      [doi:10.1145/38713.38742](http://dx.doi.org/10.1145/38713.38742)
+      [doi:10.1145/38713.38742](https://dx.doi.org/10.1145/38713.38742)
 
 1.  Pat Helland:
       “[Memories, Guesses, and Apologies](https://web.archive.org/web/20160304020907/http://blogs.msdn.com/b/pathelland/archive/2007/05/15/memories-guesses-and-apologies.aspx),”
@@ -245,7 +245,7 @@ Chapter 12 References
 1.  Yoongu Kim, Ross Daly, Jeremie Kim, et al.:
     “[Flipping Bits in Memory Without Accessing Them: An Experimental Study of DRAM Disturbance Errors](https://users.ece.cmu.edu/~yoonguk/papers/kim-isca14.pdf),” at *41st Annual
     International Symposium on Computer Architecture* (ISCA), June 2014.
-    [doi:10.1145/2678373.2665726](http://dx.doi.org/10.1145/2678373.2665726)
+    [doi:10.1145/2678373.2665726](https://dx.doi.org/10.1145/2678373.2665726)
 
 1.  Mark Seaborn and Thomas Dullien:
     “[Exploiting the DRAM Rowhammer Bug to Gain Kernel Privileges](https://googleprojectzero.blogspot.co.uk/2015/03/exploiting-dram-rowhammer-bug-to-gain.html),” *googleprojectzero.blogspot.co.uk*, March 9,
@@ -287,17 +287,17 @@ Chapter 12 References
 
 1.  Ralph C. Merkle:
     “[A Digital Signature Based on a Conventional Encryption Function](https://people.eecs.berkeley.edu/~raluca/cs261-f15/readings/merkle.pdf),” at *CRYPTO '87*, August 1987.
-    [doi:10.1007/3-540-48184-2_32](http://dx.doi.org/10.1007/3-540-48184-2_32)
+    [doi:10.1007/3-540-48184-2_32](https://dx.doi.org/10.1007/3-540-48184-2_32)
 
 1.  Ben Laurie:
     “[Certificate Transparency](http://queue.acm.org/detail.cfm?id=2668154),” *ACM
     Queue*, volume 12, number 8, pages 10-19, August 2014.
-    [doi:10.1145/2668152.2668154](http://dx.doi.org/10.1145/2668152.2668154)
+    [doi:10.1145/2668152.2668154](https://dx.doi.org/10.1145/2668152.2668154)
 
 1.  Mark D. Ryan:
     “[Enhanced Certificate Transparency and End-to-End Encrypted Mail](https://www.ndss-symposium.org/wp-content/uploads/2017/09/12_2_1.pdf),”
     at *Network and Distributed System Security Symposium* (NDSS), February 2014.
-    [doi:10.14722/ndss.2014.23379](http://dx.doi.org/10.14722/ndss.2014.23379)
+    [doi:10.14722/ndss.2014.23379](https://dx.doi.org/10.14722/ndss.2014.23379)
 
 1.  “[ACM Code of Ethics and Professional Conduct](https://www.acm.org/code-of-ethics),”
     Association for Computing Machinery, *acm.org*, 2018.
@@ -314,7 +314,7 @@ Chapter 12 References
 
 1.  Logan Kugler:
     “[What Happens When Big Data Blunders?](http://cacm.acm.org/magazines/2016/6/202655-what-happens-when-big-data-blunders/fulltext),” *Communications of the ACM*, volume 59, number 6, pages
-15–16, June 2016. [doi:10.1145/2911975](http://dx.doi.org/10.1145/2911975)
+15–16, June 2016. [doi:10.1145/2911975](https://dx.doi.org/10.1145/2911975)
 
 1.  Bill Davidow:
     “[Welcome to Algorithmic Prison](http://www.theatlantic.com/technology/archive/2014/02/welcome-to-algorithmic-prison/283985/),” *theatlantic.com*, February 20, 2014.
@@ -377,7 +377,7 @@ Chapter 12 References
 1.  Shoshana Zuboff:
     “[Big Other: Surveillance Capitalism and the Prospects of an Information Civilization](http://papers.ssrn.com/sol3/papers.cfm?abstract_id=2594754),” *Journal of Information
     Technology*, volume 30, number 1, pages 75–89, April 2015.
-    [doi:10.1057/jit.2015.5](http://dx.doi.org/10.1057/jit.2015.5)
+    [doi:10.1057/jit.2015.5](https://dx.doi.org/10.1057/jit.2015.5)
 
 1.  Carina C. Zona:
     “[Consequences of an Insightful Algorithm](https://www.youtube.com/watch?v=YRI40A4tyWU),”
@@ -398,7 +398,7 @@ Chapter 12 References
 
 1.  Lena Ulbricht and Maximilian von Grafenstein:
     “[Big Data: Big Power Shifts?](http://policyreview.info/articles/analysis/big-data-big-power-shifts),” *Internet Policy Review*, volume 5, number 1, March 2016.
-    [doi:10.14763/2016.1.406](http://dx.doi.org/10.14763/2016.1.406)
+    [doi:10.14763/2016.1.406](https://dx.doi.org/10.14763/2016.1.406)
 
 1.  Ellen P. Goodman and Julia Powles:
     “[Facebook and Google: Most Powerful and Secretive Empires We've Ever Known](https://www.theguardian.com/technology/2016/sep/28/google-facebook-powerful-secretive-empire-transparency),” *theguardian.com*, September 28,
@@ -414,7 +414,7 @@ Chapter 12 References
 1.  Michiel Rhoen:
     “[Beyond Consent: Improving Data Protection Through Consumer Protection Law](http://policyreview.info/articles/analysis/beyond-consent-improving-data-protection-through-consumer-protection-law),” *Internet Policy
     Review*, volume 5, number 1, March 2016.
-    [doi:10.14763/2016.1.404](http://dx.doi.org/10.14763/2016.1.404)
+    [doi:10.14763/2016.1.404](https://dx.doi.org/10.14763/2016.1.404)
 
 1.  Jessica Leber:
     “[Your Data Footprint Is Affecting Your Life in Ways You Can’t Even Imagine](https://www.fastcoexist.com/3057514/your-data-footprint-is-affecting-your-life-in-ways-you-cant-even-imagine),” *fastcoexist.com*, March 15,
@@ -433,4 +433,3 @@ Chapter 12 References
 
 1.  Phillip Rogaway:
     “[The Moral Character of Cryptographic Work](http://web.cs.ucdavis.edu/~rogaway/papers/moral-fn.pdf),” Cryptology ePrint 2015/1162, December 2015.
-

--- a/chapter-12-refs.md
+++ b/chapter-12-refs.md
@@ -62,7 +62,7 @@ Chapter 12 References
 1.  Dennis M. Ritchie and Ken Thompson:
     “[The UNIX Time-Sharing System](http://web.eecs.utk.edu/~qcao1/cs560/papers/paper-unix.pdf),”
     *Communications of the ACM*, volume 17, number 7, pages 365–375, July 1974.
-    [doi:10.1145/361011.361061](https://dx.doi.org/10.1145/361011.361061)
+    [doi:10.1145/361011.361061](https://doi.org/10.1145/361011.361061)
 
 1.  Eric A. Brewer and Joseph M. Hellerstein:
     “[CS262a: Advanced Topics in Computer Systems](http://people.eecs.berkeley.edu/~brewer/cs262/systemr.html),” lecture notes, University of California, Berkeley, *cs.berkeley.edu*,
@@ -75,7 +75,7 @@ Chapter 12 References
 1.  Jennie Duggan,
       Aaron J. Elmore, Michael Stonebraker, et al.:
       “[The BigDAWG Polystore   System](https://dspace.mit.edu/handle/1721.1/100936),” *ACM SIGMOD Record*, volume 44, number 2, pages 11–16, June 2015.
-      [doi:10.1145/2814710.2814713](https://dx.doi.org/10.1145/2814710.2814713)
+      [doi:10.1145/2814710.2814713](https://doi.org/10.1145/2814710.2814713)
 
 1.  Patrycja Dybka:
       “[Foreign   Data Wrappers for PostgreSQL](http://www.vertabelo.com/blog/technical-articles/foreign-data-wrappers-for-postgresql),” *vertabelo.com*, March 24, 2015.
@@ -98,7 +98,7 @@ Chapter 12 References
 1.  Derek G Murray, Frank McSherry, Rebecca Isaacs, et al.:
     “[Naiad: A Timely Dataflow System](http://sigops.org/s/conferences/sosp/2013/papers/p439-murray.pdf),”
     at *24th ACM Symposium on Operating Systems Principles* (SOSP), pages 439–455, November 2013.
-    [doi:10.1145/2517349.2522738](https://dx.doi.org/10.1145/2517349.2522738)
+    [doi:10.1145/2517349.2522738](https://doi.org/10.1145/2517349.2522738)
 
 1.  Gwen Shapira:
     “[We have a bunch of customers who are implementing ‘database inside-out’ concept and they all ask ‘is anyone else doing it? are we crazy?’](https://twitter.com/gwenshap/status/758800071110430720)” *twitter.com*, July 28, 2016.
@@ -115,12 +115,12 @@ Chapter 12 References
 1.  Evan Czaplicki and Stephen Chong:
     “[Asynchronous Functional Reactive Programming for GUIs](http://people.seas.harvard.edu/~chong/pubs/pldi13-elm.pdf),” at *34th ACM SIGPLAN Conference on Programming Language
     Design and Implementation* (PLDI), June 2013.
-    [doi:10.1145/2491956.2462161](https://dx.doi.org/10.1145/2491956.2462161)
+    [doi:10.1145/2491956.2462161](https://doi.org/10.1145/2491956.2462161)
 
 1.  Engineer Bainomugisha, Andoni Lombide Carreton,
     Tom van Cutsem, Stijn Mostinckx, and Wolfgang de Meuter:
     “[A Survey on Reactive Programming](http://soft.vub.ac.be/Publications/2012/vub-soft-tr-12-13.pdf),” *ACM Computing Surveys*, volume 45, number 4, pages 1–34, August 2013.
-    [doi:10.1145/2501654.2501666](https://dx.doi.org/10.1145/2501654.2501666)
+    [doi:10.1145/2501654.2501666](https://doi.org/10.1145/2501654.2501666)
 
 1.  Peter Alvaro, Neil Conway, Joseph M. Hellerstein, and William R. Marczak:
     “[Consistency Analysis in Bloom: A CALM and Collected Approach](https://dsf.berkeley.edu/cs286/papers/calm-cidr2011.pdf),”
@@ -139,7 +139,7 @@ Chapter 12 References
 1.  Peter Bailis, Alan Fekete, Michael J Franklin,
     et al.: “[Feral Concurrency Control: An Empirical Investigation of Modern Application Integrity](http://www.bailis.org/papers/feral-sigmod2015.pdf),” at *ACM International Conference on
     Management of Data* (SIGMOD), June 2015.
-    [doi:10.1145/2723372.2737784](https://dx.doi.org/10.1145/2723372.2737784)
+    [doi:10.1145/2723372.2737784](https://doi.org/10.1145/2723372.2737784)
 
 1.  Guy Steele:
     “[Re: Need for Macros (Was Re: Icon)](https://people.csail.mit.edu/gregs/ll1-discuss-archive-html/msg01134.html),” email to *ll1-discuss* mailing list, *people.csail.mit.edu*, December 24,
@@ -148,13 +148,13 @@ Chapter 12 References
 1.  David Gelernter:
     “[Generative Communication in Linda](http://cseweb.ucsd.edu/groups/csag/html/teaching/cse291s03/Readings/p80-gelernter.pdf),” *ACM Transactions on Programming Languages and Systems*
     (TOPLAS), volume 7, number 1, pages 80–112, January 1985.
-    [doi:10.1145/2363.2433](https://dx.doi.org/10.1145/2363.2433)
+    [doi:10.1145/2363.2433](https://doi.org/10.1145/2363.2433)
 
 1.  Patrick Th. Eugster, Pascal A. Felber,
     Rachid Guerraoui, and Anne-Marie Kermarrec:
     “[The Many Faces of Publish/Subscribe](http://www.cs.ru.nl/~pieter/oss/manyfaces.pdf),”
     *ACM Computing Surveys*, volume 35, number 2, pages 114–131, June 2003.
-    [doi:10.1145/857076.857078](https://dx.doi.org/10.1145/857076.857078)
+    [doi:10.1145/857076.857078](https://doi.org/10.1145/857076.857078)
 
 1.  Ben Stopford:
     “[Microservices in a Streaming World](https://www.infoq.com/presentations/microservices-streaming),” at *QCon London*, March 2016.
@@ -170,7 +170,7 @@ Chapter 12 References
     Protzenko, and Manuel Fähndrich:
     “[Global Sequence Protocol: A Robust Abstraction for Replicated Shared State](http://drops.dagstuhl.de/opus/volltexte/2015/5238/),” at *29th European Conference on Object-Oriented
     Programming* (ECOOP), July 2015.
-    [doi:10.4230/LIPIcs.ECOOP.2015.568](https://dx.doi.org/10.4230/LIPIcs.ECOOP.2015.568)
+    [doi:10.4230/LIPIcs.ECOOP.2015.568](https://doi.org/10.4230/LIPIcs.ECOOP.2015.568)
 
 1.  Mark Soper:
     “[Clearing Up React Data Management Confusion with Flux, Redux, and Relay](https://medium.com/@marksoper/clearing-up-react-data-management-confusion-with-flux-redux-and-relay-aad504e63cae),” *medium.com*, December 3, 2015.
@@ -199,7 +199,7 @@ Chapter 12 References
 1.  Arthur J. Bernstein, Philip M. Lewis, and Shiyong Lu:
     “[Semantic Conditions for Correctness at Different Isolation Levels](http://db.cs.berkeley.edu/cs286/papers/isolation-icde2000.pdf),” at *16th International Conference on Data
     Engineering* (ICDE), February 2000.
-    [doi:10.1109/ICDE.2000.839387](https://dx.doi.org/10.1109/ICDE.2000.839387)
+    [doi:10.1109/ICDE.2000.839387](https://doi.org/10.1109/ICDE.2000.839387)
 
 1.  Sudhir Jorwekar, Alan Fekete, Krithi Ramamritham, and
     S. Sudarshan: “[Automating the Detection of Snapshot Isolation Anomalies](http://www.vldb.org/conf/2007/papers/industrial/p1263-jorwekar.pdf),” at *33rd International Conference on Very
@@ -215,7 +215,7 @@ Chapter 12 References
 1.  Jerome H. Saltzer, David P. Reed, and David D. Clark:
     “[End-to-End Arguments in System Design](https://groups.csail.mit.edu/ana/Publications/PubPDFs/End-to-End%20Arguments%20in%20System%20Design.pdf),”
     *ACM Transactions on Computer Systems*, volume 2, number 4, pages 277–288, November 1984.
-    [doi:10.1145/357401.357402](https://dx.doi.org/10.1145/357401.357402)
+    [doi:10.1145/357401.357402](https://doi.org/10.1145/357401.357402)
 
 1.  Peter Bailis, Alan Fekete, Michael J. Franklin, et al.:
     “[Coordination-Avoiding Database Systems](http://arxiv.org/pdf/1402.2237.pdf),”
@@ -227,7 +227,7 @@ Chapter 12 References
 1.  Douglas B Terry, Marvin M Theimer, Karin Petersen, et al.:
     “[Managing Update Conflicts in Bayou, a Weakly Connected Replicated Storage System](http://css.csail.mit.edu/6.824/2014/papers/bayou-conflicts.pdf),” at *15th ACM Symposium on Operating
     Systems Principles* (SOSP), pages 172–182, December 1995.
-    [doi:10.1145/224056.224070](https://dx.doi.org/10.1145/224056.224070)
+    [doi:10.1145/224056.224070](https://doi.org/10.1145/224056.224070)
 
 1.  Jim Gray:
       “[The Transaction Concept: Virtues and Limitations](http://jimgray.azurewebsites.net/papers/thetransactionconcept.pdf),”
@@ -236,7 +236,7 @@ Chapter 12 References
 1.  Hector Garcia-Molina and Kenneth Salem:
       “[Sagas](http://www.cs.cornell.edu/andru/cs711/2002fa/reading/sagas.pdf),” at
       *ACM International Conference on Management of Data* (SIGMOD), May 1987.
-      [doi:10.1145/38713.38742](https://dx.doi.org/10.1145/38713.38742)
+      [doi:10.1145/38713.38742](https://doi.org/10.1145/38713.38742)
 
 1.  Pat Helland:
       “[Memories, Guesses, and Apologies](https://web.archive.org/web/20160304020907/http://blogs.msdn.com/b/pathelland/archive/2007/05/15/memories-guesses-and-apologies.aspx),”
@@ -245,7 +245,7 @@ Chapter 12 References
 1.  Yoongu Kim, Ross Daly, Jeremie Kim, et al.:
     “[Flipping Bits in Memory Without Accessing Them: An Experimental Study of DRAM Disturbance Errors](https://users.ece.cmu.edu/~yoonguk/papers/kim-isca14.pdf),” at *41st Annual
     International Symposium on Computer Architecture* (ISCA), June 2014.
-    [doi:10.1145/2678373.2665726](https://dx.doi.org/10.1145/2678373.2665726)
+    [doi:10.1145/2678373.2665726](https://doi.org/10.1145/2678373.2665726)
 
 1.  Mark Seaborn and Thomas Dullien:
     “[Exploiting the DRAM Rowhammer Bug to Gain Kernel Privileges](https://googleprojectzero.blogspot.co.uk/2015/03/exploiting-dram-rowhammer-bug-to-gain.html),” *googleprojectzero.blogspot.co.uk*, March 9,
@@ -287,17 +287,17 @@ Chapter 12 References
 
 1.  Ralph C. Merkle:
     “[A Digital Signature Based on a Conventional Encryption Function](https://people.eecs.berkeley.edu/~raluca/cs261-f15/readings/merkle.pdf),” at *CRYPTO '87*, August 1987.
-    [doi:10.1007/3-540-48184-2_32](https://dx.doi.org/10.1007/3-540-48184-2_32)
+    [doi:10.1007/3-540-48184-2_32](https://doi.org/10.1007/3-540-48184-2_32)
 
 1.  Ben Laurie:
     “[Certificate Transparency](http://queue.acm.org/detail.cfm?id=2668154),” *ACM
     Queue*, volume 12, number 8, pages 10-19, August 2014.
-    [doi:10.1145/2668152.2668154](https://dx.doi.org/10.1145/2668152.2668154)
+    [doi:10.1145/2668152.2668154](https://doi.org/10.1145/2668152.2668154)
 
 1.  Mark D. Ryan:
     “[Enhanced Certificate Transparency and End-to-End Encrypted Mail](https://www.ndss-symposium.org/wp-content/uploads/2017/09/12_2_1.pdf),”
     at *Network and Distributed System Security Symposium* (NDSS), February 2014.
-    [doi:10.14722/ndss.2014.23379](https://dx.doi.org/10.14722/ndss.2014.23379)
+    [doi:10.14722/ndss.2014.23379](https://doi.org/10.14722/ndss.2014.23379)
 
 1.  “[ACM Code of Ethics and Professional Conduct](https://www.acm.org/code-of-ethics),”
     Association for Computing Machinery, *acm.org*, 2018.
@@ -314,7 +314,7 @@ Chapter 12 References
 
 1.  Logan Kugler:
     “[What Happens When Big Data Blunders?](http://cacm.acm.org/magazines/2016/6/202655-what-happens-when-big-data-blunders/fulltext),” *Communications of the ACM*, volume 59, number 6, pages
-15–16, June 2016. [doi:10.1145/2911975](https://dx.doi.org/10.1145/2911975)
+15–16, June 2016. [doi:10.1145/2911975](https://doi.org/10.1145/2911975)
 
 1.  Bill Davidow:
     “[Welcome to Algorithmic Prison](http://www.theatlantic.com/technology/archive/2014/02/welcome-to-algorithmic-prison/283985/),” *theatlantic.com*, February 20, 2014.
@@ -377,7 +377,7 @@ Chapter 12 References
 1.  Shoshana Zuboff:
     “[Big Other: Surveillance Capitalism and the Prospects of an Information Civilization](http://papers.ssrn.com/sol3/papers.cfm?abstract_id=2594754),” *Journal of Information
     Technology*, volume 30, number 1, pages 75–89, April 2015.
-    [doi:10.1057/jit.2015.5](https://dx.doi.org/10.1057/jit.2015.5)
+    [doi:10.1057/jit.2015.5](https://doi.org/10.1057/jit.2015.5)
 
 1.  Carina C. Zona:
     “[Consequences of an Insightful Algorithm](https://www.youtube.com/watch?v=YRI40A4tyWU),”
@@ -398,7 +398,7 @@ Chapter 12 References
 
 1.  Lena Ulbricht and Maximilian von Grafenstein:
     “[Big Data: Big Power Shifts?](http://policyreview.info/articles/analysis/big-data-big-power-shifts),” *Internet Policy Review*, volume 5, number 1, March 2016.
-    [doi:10.14763/2016.1.406](https://dx.doi.org/10.14763/2016.1.406)
+    [doi:10.14763/2016.1.406](https://doi.org/10.14763/2016.1.406)
 
 1.  Ellen P. Goodman and Julia Powles:
     “[Facebook and Google: Most Powerful and Secretive Empires We've Ever Known](https://www.theguardian.com/technology/2016/sep/28/google-facebook-powerful-secretive-empire-transparency),” *theguardian.com*, September 28,
@@ -414,7 +414,7 @@ Chapter 12 References
 1.  Michiel Rhoen:
     “[Beyond Consent: Improving Data Protection Through Consumer Protection Law](http://policyreview.info/articles/analysis/beyond-consent-improving-data-protection-through-consumer-protection-law),” *Internet Policy
     Review*, volume 5, number 1, March 2016.
-    [doi:10.14763/2016.1.404](https://dx.doi.org/10.14763/2016.1.404)
+    [doi:10.14763/2016.1.404](https://doi.org/10.14763/2016.1.404)
 
 1.  Jessica Leber:
     “[Your Data Footprint Is Affecting Your Life in Ways You Can’t Even Imagine](https://www.fastcoexist.com/3057514/your-data-footprint-is-affecting-your-life-in-ways-you-cant-even-imagine),” *fastcoexist.com*, March 15,


### PR DESCRIPTION
These two commits bring the DOI URLs in line with current best practices as recommended by the International DOI Foundation. We now use HTTPS and omit 'dx.' from the domain.

Related:
- [CrossRef.org on HTTPS](https://www.crossref.org/blog/linking-dois-using-https-the-background-to-our-new-guidelines/#:~:text=The%20pressure%20to%20move%20to%20HTTPS)
- [DataCite on HTTPS](https://support.datacite.org/docs/datacite-doi-display-guidelines#:~:text=Why%20should%20members%20use%20HTTPS%3F)
- [APA on domain](https://apastyle.apa.org/style-grammar-guidelines/references/dois-urls#:~:text=The%20preferred%20format,an%20older%20format.)
- [DataCite on domain](https://support.datacite.org/docs/datacite-doi-display-guidelines#:~:text=Originally%20the%20dx%20separated%20the%20DOI%20resolver%20from%20the%20International%20DOI%20Foundation%20(IDF)%20website%20but%20this%20changed%20a%20few%20years%20ago%20and%20the%20IDF%20recommends%20http%3A//doi.org%20as%20the%20preferred%20form%20for%20the%20domain%20name%20in%20DOI%20URLs.)