### PR TITLE
ci: add link checker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,0 +1,29 @@
+name: Links
+
+on:
+  repository_dispatch:
+  workflow_dispatch:
+  schedule:
+    - cron: "20 4 * * 1" # 04:20 UTC on Mondays
+
+jobs:
+  linkChecker:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write # required for peter-evans/create-issue-from-file
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          fail: false
+
+      - name: Create Issue From File
+        if: steps.lychee.outputs.exit_code != 0
+        uses: peter-evans/create-issue-from-file@v5
+        with:
+          title: Link Checker Report
+          content-filepath: ./lychee/out.md
+          labels: report, automated issue

--- a/.github/workflows/lint-github-actions.yml
+++ b/.github/workflows/lint-github-actions.yml
@@ -1,0 +1,16 @@
+name: Lint GitHub Actions workflows
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+  workflow_dispatch:
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check workflow files
+        uses: docker://rhysd/actionlint:latest
+        with:
+          args: -color


### PR DESCRIPTION
A lot of contributions to this repo are just fixes for broken links. This PR will make it easier to identify broken links.

Contributions:
- 00bbc41a89be7e02ea1a66e1d47a5a19d60d3071 is the primary contribution. In `.github/workflows/links.yml`, we use the [`lychee`](https://github.com/lycheeverse/lychee-action) GitHub action (in conjunction with [Create Issue From File](https://github.com/peter-evans/create-issue-from-file) to a) scan the repo for broken links and b) create a GitHub Issue from the report file produced by `lychee`. I've set it to run weekly early Monday mornings. You can see what the report would like [on my fork](https://github.com/michen00/ddia-references/issues/2).
- In f9d0c579d921359e6ef808cb8bf2e8e22516bc7e, I added an action to lint other actions with [`actionlint`](https://github.com/rhysd/actionlint). We can revert this if you feel it clutters the repo.
- To keep the actions updated, I added dependabot.yml in 513963af04ea030ddf9a9473c41fc5b7fc3471e8. ([Dependabot docs](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot#enabling-dependabot-version-updates-for-actions)).

Notes:
- I'm not sure if `lychee` will check relative links, but we aren't using those in README.md yet anyway.
- An interesting follow-on project could be to create a tool that consults WayBack or other internet archives. Maybe it could 'subscribe' to the Issues on this repo and/or send verified links to the Internet Archive too.