### PR TITLE
Fix more broken links

### DIFF
--- a/chapter-06-refs.md
+++ b/chapter-06-refs.md
@@ -82,7 +82,7 @@ Chapter 6 References
     “[Reroute API Explained](https://web.archive.org/web/20190706215750/http://elasticsearchserverbook.com/reroute-api-explained/),”
     *elasticsearchserverbook.com*, September 30, 2013.
 
-1.  “[Project Voldemort Documentation](http://www.project-voldemort.com/voldemort/),” *project-voldemort.com*.
+1.  “[Project Voldemort Documentation](https://web.archive.org/web/20250107145644/http://www.project-voldemort.com/voldemort/),” *project-voldemort.com*.
 
 1.  Enis Soztutar:
     “[Apache HBase Region Splitting and Merging](http://hortonworks.com/blog/apache-hbase-region-splitting-and-merging/),” *hortonworks.com*, February 1, 2013.

--- a/chapter-09-refs.md
+++ b/chapter-09-refs.md
@@ -435,7 +435,7 @@ Chapter 9 References
     [doi:10.4230/LIPIcs.OPODIS.2016.25](http://dx.doi.org/10.4230/LIPIcs.OPODIS.2016.25)
 
 1.  Heidi Howard and Jon Crowcroft:
-    “[Coracle: Evaluating Consensus at the Internet Edge](http://www.sigcomm.org/sites/default/files/ccr/papers/2015/August/2829988-2790010.pdf),”
+    “[Coracle: Evaluating Consensus at the Internet Edge](https://web.archive.org/web/20220201190652/https://www.sigcomm.org/sites/default/files/ccr/papers/2015/August/2829988-2790010.pdf),”
     at *Annual Conference of the ACM Special Interest Group on Data Communication* (SIGCOMM), August 2015.
     [doi:10.1145/2829988.2790010](http://dx.doi.org/10.1145/2829988.2790010)
 

--- a/chapter-10-refs.md
+++ b/chapter-10-refs.md
@@ -119,7 +119,7 @@ Chapter 10 References
     “[Hive – A Petabyte Scale Data Warehouse Using Hadoop](http://i.stanford.edu/~ragho/hive-icde2010.pdf),” at *26th IEEE International Conference on Data Engineering* (ICDE), March 2010.
     [doi:10.1109/ICDE.2010.5447738](http://dx.doi.org/10.1109/ICDE.2010.5447738)
 
-1.  “[Cascading 3.0 User Guide](http://docs.cascading.org/cascading/3.0/userguide/),” Concurrent, Inc., *docs.cascading.org*, January 2016.
+1.  “[Cascading 3.0 User Guide](https://web.archive.org/web/20231206195311/http://docs.cascading.org/cascading/3.0/userguide/),” Concurrent, Inc., *docs.cascading.org*, January 2016.
 
 1.  “[Apache Crunch User Guide](https://crunch.apache.org/user-guide.html),” Apache Software Foundation, *crunch.apache.org*.
 

--- a/chapter-10-refs.md
+++ b/chapter-10-refs.md
@@ -216,7 +216,7 @@ Chapter 10 References
     at *Strata+Hadoop World*, February 2015.
 
 1.  Vinod Kumar Vavilapalli, Arun C. Murthy, Chris Douglas, et al.:
-    “[Apache Hadoop YARN: Yet Another Resource Negotiator](http://www.socc2013.org/home/program/a5-vavilapalli.pdf),” at *4th ACM Symposium on Cloud Computing* (SoCC), October 2013.
+    “[Apache Hadoop YARN: Yet Another Resource Negotiator](https://www.cs.cmu.edu/~garth/15719/papers/yarn.pdf),” at *4th ACM Symposium on Cloud Computing* (SoCC), October 2013.
     [doi:10.1145/2523616.2523633](http://dx.doi.org/10.1145/2523616.2523633)
 
 1.  Abhishek Verma, Luis Pedrosa, Madhukar Korupolu, et al.:

--- a/chapter-12-refs.md
+++ b/chapter-12-refs.md
@@ -78,7 +78,7 @@ Chapter 12 References
       [doi:10.1145/2814710.2814713](http://dx.doi.org/10.1145/2814710.2814713)
 
 1.  Patrycja Dybka:
-      “[Foreign   Data Wrappers for PostgreSQL](http://www.vertabelo.com/blog/technical-articles/foreign-data-wrappers-for-postgresql),” *vertabelo.com*, March 24, 2015.
+    “[Foreign Data Wrappers for PostgreSQL](https://web.archive.org/web/20221003115732/https://www.vertabelo.com/blog/foreign-data-wrappers-for-postgresql/),” *vertabelo.com*, March 24, 2015.
 
 1.  David B. Lomet, Alan Fekete, Gerhard Weikum, and Mike Zwilling:
       “[Unbundling   Transaction Services in the Cloud](https://www.microsoft.com/en-us/research/publication/unbundling-transaction-services-in-the-cloud/),” at *4th Biennial Conference on Innovative Data Systems
@@ -343,7 +343,7 @@ Chapter 12 References
     “[European Union Regulations on Algorithmic Decision-Making and a ‘Right to Explanation’](https://arxiv.org/abs/1606.08813),” *arXiv:1606.08813*, August 31,
     2016.
 
-1.  “[A Review of the Data Broker Industry: Collection, Use, and Sale of Consumer Data for Marketing Purposes](http://educationnewyork.com/files/rockefeller_databroker.pdf),”
+1.  “[A Review of the Data Broker Industry: Collection, Use, and Sale of Consumer Data for Marketing Purposes](https://web.archive.org/web/20240619042302/http://educationnewyork.com/files/rockefeller_databroker.pdf),”
     Staff Report, *United States Senate Committee on Commerce, Science, and Transportation*, *commerce.senate.gov*, December 2013.
 
 1.  Olivia Solon:


### PR DESCRIPTION
Maybe a one-off treatment may be sufficient for 1st edition links:

1. Proactively send each non-DOI, non-web.archive.org link to the Internet Archive and replace them in the 1st edition references.
1. The remaining links are dead or inaccessible to the Internet Archive. Repeat with an alternative archive service.
1. The remaining links require manual resolution or have been lost to time :(

The low-precision link checker reported about 135 unverified non-DOI, non-web.archive.org links (#45). Assuming that nearly all the verified non-DOI, non-web.archive.org links can be archived, perhaps the magnitude of manual resolution can be surmounted by a single motivated librarian.

Until then, I fixed 6 more links 👍 